### PR TITLE
fix: use platform-native keyboard shortcuts on macOS

### DIFF
--- a/docs/technical/keyboard-shortcuts.md
+++ b/docs/technical/keyboard-shortcuts.md
@@ -4,11 +4,18 @@
 
 Global keyboard shortcuts for file operations, tab management, and navigation. Implemented in `src/app.rs` using egui's input handling with deferred action execution to avoid borrow conflicts.
 
+**Platform Note:** Ferrite uses standard platform modifiers:
+- **macOS:** Command (Cmd) key
+- **Windows/Linux:** Control (Ctrl) key
+
+The shortcuts below show `Cmd/Ctrl` to indicate this cross-platform behavior.
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/app.rs` | `KeyboardAction` enum, `handle_keyboard_shortcuts()`, action handlers |
+| `src/app.rs` | `KeyboardAction` enum, `handle_keyboard_shortcuts()`, action handlers, `modifier_symbol()` |
+| `src/ui/ribbon.rs` | Tooltip display with platform-aware modifier names |
 
 ## Shortcut Reference
 
@@ -16,68 +23,88 @@ Global keyboard shortcuts for file operations, tab management, and navigation. I
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+N** | New file | Creates new empty tab |
-| **Ctrl+O** | Open file | Opens native file dialog |
-| **Ctrl+S** | Save | Saves current file (or triggers Save As if no path) |
-| **Ctrl+Shift+S** | Save As | Opens native save dialog |
+| **Cmd/Ctrl+N** | New file | Creates new empty tab |
+| **Cmd/Ctrl+O** | Open file | Opens native file dialog |
+| **Cmd/Ctrl+S** | Save | Saves current file (or triggers Save As if no path) |
+| **Cmd/Ctrl+Shift+S** | Save As | Opens native save dialog |
 
 ### Tab Operations
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+T** | New tab | Creates new empty tab |
-| **Ctrl+W** | Close tab | Closes current tab (prompts if unsaved) |
-| **Ctrl+Tab** | Next tab | Switches to next tab (wraps to first) |
-| **Ctrl+Shift+Tab** | Previous tab | Switches to previous tab (wraps to last) |
+| **Cmd/Ctrl+T** | New tab | Creates new empty tab |
+| **Cmd/Ctrl+W** | Close tab | Closes current tab (prompts if unsaved) |
+| **Cmd/Ctrl+Tab** | Next tab | Switches to next tab (wraps to first) |
+| **Cmd/Ctrl+Shift+Tab** | Previous tab | Switches to previous tab (wraps to last) |
 
 ### Edit Operations
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+Z** | Undo | Undo last change |
-| **Ctrl+Y** | Redo | Redo last undone change |
-| **Ctrl+F** | Find | Open find panel |
-| **Ctrl+H** | Find & Replace | Open find/replace panel |
-| **Ctrl+A** | Select All | Select all text |
+| **Cmd/Ctrl+Z** | Undo | Undo last change |
+| **Cmd/Ctrl+Y** | Redo | Redo last undone change |
+| **Cmd/Ctrl+Shift+Z** | Redo | Redo (alternative) |
+| **Cmd/Ctrl+F** | Find | Open find panel |
+| **Cmd/Ctrl+H** | Find & Replace | Open find/replace panel |
+| **Cmd/Ctrl+A** | Select All | Select all text |
 
 ### View Operations
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+E** | Toggle View | Switch between Raw and Rendered modes |
-| **Ctrl+Shift+O** | Toggle Outline | Show/hide document outline panel |
-| **Ctrl++** | Zoom In | Increase font size |
-| **Ctrl+-** | Zoom Out | Decrease font size |
-| **Ctrl+0** | Reset Zoom | Reset font size to default |
-| **Ctrl+,** | Settings | Open settings panel |
+| **Cmd/Ctrl+E** | Toggle View | Switch between Raw and Rendered modes |
+| **Cmd/Ctrl+Shift+O** | Toggle Outline | Show/hide document outline panel |
+| **Cmd/Ctrl++** | Zoom In | Increase font size |
+| **Cmd/Ctrl+-** | Zoom Out | Decrease font size |
+| **Cmd/Ctrl+0** | Reset Zoom | Reset font size to default |
+| **Cmd/Ctrl+,** | Settings | Open settings panel |
 | **F1** | About/Help | Open about and shortcuts reference |
 
 ### Formatting (Markdown)
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+B** | Bold | Toggle bold formatting |
-| **Ctrl+I** | Italic | Toggle italic formatting |
-| **Ctrl+K** | Link | Insert link |
-| **Ctrl+`** | Inline Code | Toggle inline code |
+| **Cmd/Ctrl+B** | Bold | Toggle bold formatting |
+| **Cmd/Ctrl+I** | Italic | Toggle italic formatting |
+| **Cmd/Ctrl+K** | Link | Insert link |
+| **Cmd/Ctrl+`** | Inline Code | Toggle inline code |
+| **Cmd/Ctrl+1-6** | Headings | Apply heading level 1-6 |
 
 ### Workspace Operations
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+P** | Quick File Switcher | Open file palette (workspace mode) |
-| **Ctrl+Shift+F** | Search in Files | Search across workspace (workspace mode) |
-| **Ctrl+Shift+E** | Toggle File Tree | Show/hide file tree panel |
+| **Cmd/Ctrl+P** | Quick File Switcher | Open file palette (workspace mode) |
+| **Cmd/Ctrl+Shift+F** | Search in Files | Search across workspace (workspace mode) |
+| **Cmd/Ctrl+Shift+E** | Export HTML | Export current document as HTML |
 
 ### Navigation
 
 | Shortcut | Action | Description |
 |----------|--------|-------------|
-| **Ctrl+G** | Go to Line | Jump to specific line number |
+| **Cmd/Ctrl+G** | Go to Line | Jump to specific line number |
 | **F3** | Find Next | Jump to next search match |
 | **Shift+F3** | Find Previous | Jump to previous search match |
 
 ## Implementation
+
+### Cross-Platform Modifier Handling
+
+egui provides built-in cross-platform support through `modifiers.command`:
+- On macOS: Maps to Command key
+- On Windows/Linux: Maps to Control key
+
+```rust
+/// Get the display name for the primary modifier key.
+/// Returns "Cmd" on macOS, "Ctrl" on Windows/Linux.
+pub fn modifier_symbol() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Cmd"
+    } else {
+        "Ctrl"
+    }
+}
+```
 
 ### KeyboardAction Enum
 
@@ -87,33 +114,33 @@ Actions are detected in an input closure and deferred for execution to avoid bor
 #[derive(Debug, Clone, Copy)]
 enum KeyboardAction {
     // File operations
-    Save,           // Ctrl+S
-    SaveAs,         // Ctrl+Shift+S
-    Open,           // Ctrl+O
-    New,            // Ctrl+N
-    NewTab,         // Ctrl+T
-    CloseTab,       // Ctrl+W
-    NextTab,        // Ctrl+Tab
-    PrevTab,        // Ctrl+Shift+Tab
+    Save,           // Cmd/Ctrl+S
+    SaveAs,         // Cmd/Ctrl+Shift+S
+    Open,           // Cmd/Ctrl+O
+    New,            // Cmd/Ctrl+N
+    NewTab,         // Cmd/Ctrl+T
+    CloseTab,       // Cmd/Ctrl+W
+    NextTab,        // Cmd/Ctrl+Tab
+    PrevTab,        // Cmd/Ctrl+Shift+Tab
     // Edit operations
-    Undo,           // Ctrl+Z
-    Redo,           // Ctrl+Y
-    Find,           // Ctrl+F
-    FindReplace,    // Ctrl+H
+    Undo,           // Cmd/Ctrl+Z
+    Redo,           // Cmd/Ctrl+Y
+    Find,           // Cmd/Ctrl+F
+    FindReplace,    // Cmd/Ctrl+H
     // View operations
-    ToggleView,     // Ctrl+E
-    ToggleOutline,  // Ctrl+Shift+O
-    OpenSettings,   // Ctrl+,
+    ToggleView,     // Cmd/Ctrl+E
+    ToggleOutline,  // Cmd/Ctrl+Shift+O
+    OpenSettings,   // Cmd/Ctrl+,
     OpenAbout,      // F1
     // Workspace operations
-    QuickSwitcher,  // Ctrl+P
-    SearchInFiles,  // Ctrl+Shift+F
-    ToggleFileTree, // Ctrl+Shift+E
+    QuickSwitcher,  // Cmd/Ctrl+P
+    SearchInFiles,  // Cmd/Ctrl+Shift+F
+    ToggleFileTree, // Cmd/Ctrl+Shift+E
     // Formatting
-    FormatBold,     // Ctrl+B
-    FormatItalic,   // Ctrl+I
-    FormatLink,     // Ctrl+K
-    FormatCode,     // Ctrl+`
+    FormatBold,     // Cmd/Ctrl+B
+    FormatItalic,   // Cmd/Ctrl+I
+    FormatLink,     // Cmd/Ctrl+K
+    FormatCode,     // Cmd/Ctrl+`
 }
 ```
 
@@ -122,20 +149,20 @@ enum KeyboardAction {
 ```rust
 fn handle_keyboard_shortcuts(&mut self, ctx: &egui::Context) {
     ctx.input(|i| {
-        // Check more specific shortcuts first (Ctrl+Shift+X before Ctrl+X)
-        
-        // Ctrl+Shift+S: Save As
-        if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::S) {
+        // Check more specific shortcuts first (Cmd/Ctrl+Shift+X before Cmd/Ctrl+X)
+
+        // Cmd/Ctrl+Shift+S: Save As
+        if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::S) {
             return Some(KeyboardAction::SaveAs);
         }
-        
-        // Ctrl+S: Save (must check !shift to avoid conflict)
-        if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::S) {
+
+        // Cmd/Ctrl+S: Save (must check !shift to avoid conflict)
+        if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::S) {
             return Some(KeyboardAction::Save);
         }
-        
+
         // ... more shortcuts
-        
+
         None
     }).map(|action| {
         // Execute action after input closure
@@ -192,13 +219,13 @@ fn handle_close_current_tab(&mut self) {
 Always check more specific shortcuts first:
 
 ```rust
-// ✅ Correct order
-if ctrl && shift && key == S { SaveAs }
-if ctrl && !shift && key == S { Save }
+// Correct order
+if command && shift && key == S { SaveAs }
+if command && !shift && key == S { Save }
 
-// ❌ Wrong order - SaveAs would never trigger
-if ctrl && key == S { Save }
-if ctrl && shift && key == S { SaveAs }
+// Wrong order - SaveAs would never trigger
+if command && key == S { Save }
+if command && shift && key == S { SaveAs }
 ```
 
 ### egui Key Constants
@@ -217,10 +244,11 @@ egui::Key::Tab    // Tab key
 ### Modifier Flags
 
 ```rust
-i.modifiers.ctrl   // Ctrl key held
-i.modifiers.shift  // Shift key held
-i.modifiers.alt    // Alt key held
-i.modifiers.command // Cmd (Mac) / Win key
+i.modifiers.command // Cmd (Mac) / Ctrl (Win/Linux) - USE THIS for cross-platform
+i.modifiers.ctrl    // Raw Ctrl key (avoid for shortcuts)
+i.modifiers.shift   // Shift key held
+i.modifiers.alt     // Alt key held
+i.modifiers.mac_cmd // Mac Command key only
 ```
 
 ## Testing
@@ -231,15 +259,15 @@ Keyboard shortcuts are tested through integration testing by running the applica
 cargo run
 ```
 
-Manual test checklist:
-- [ ] Ctrl+N creates new tab
-- [ ] Ctrl+T creates new tab
-- [ ] Ctrl+O opens file dialog
-- [ ] Ctrl+S saves (or Save As if no path)
-- [ ] Ctrl+Shift+S opens Save As dialog
-- [ ] Ctrl+W closes current tab (with prompt if unsaved)
-- [ ] Ctrl+Tab cycles to next tab
-- [ ] Ctrl+Shift+Tab cycles to previous tab
+Manual test checklist (use Cmd on macOS, Ctrl on Windows/Linux):
+- [ ] Cmd/Ctrl+N creates new tab
+- [ ] Cmd/Ctrl+T creates new tab
+- [ ] Cmd/Ctrl+O opens file dialog
+- [ ] Cmd/Ctrl+S saves (or Save As if no path)
+- [ ] Cmd/Ctrl+Shift+S opens Save As dialog
+- [ ] Cmd/Ctrl+W closes current tab (with prompt if unsaved)
+- [ ] Cmd/Ctrl+Tab cycles to next tab
+- [ ] Cmd/Ctrl+Shift+Tab cycles to previous tab
 
 ## Related Documentation
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,20 @@ use eframe::egui;
 use log::{debug, info, warn};
 use std::collections::HashMap;
 
+/// Get the display name for the primary modifier key.
+/// Returns "Cmd" on macOS, "Ctrl" on Windows/Linux.
+///
+/// This is used for displaying keyboard shortcuts in the UI.
+/// The actual keyboard handling uses `egui::Modifiers::command` which
+/// automatically maps to the correct key per platform.
+pub fn modifier_symbol() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "Cmd"
+    } else {
+        "Ctrl"
+    }
+}
+
 /// Keyboard shortcut actions that need to be deferred.
 ///
 /// These actions are detected in the input handling closure and executed
@@ -3345,19 +3359,19 @@ impl FerriteApp {
     /// our undo system handles the events.
     fn consume_undo_redo_keys(&mut self, ctx: &egui::Context) {
         let consumed_action: Option<bool> = ctx.input_mut(|i| {
-            // Ctrl+Shift+Z: Redo (check first since it's more specific)
-            if i.consume_key(egui::Modifiers::CTRL | egui::Modifiers::SHIFT, egui::Key::Z) {
-                debug!("Keyboard shortcut: Ctrl+Shift+Z (Redo) - consumed before render");
+            // Cmd+Shift+Z (macOS) / Ctrl+Shift+Z (Win/Linux): Redo (check first since it's more specific)
+            if i.consume_key(egui::Modifiers::COMMAND | egui::Modifiers::SHIFT, egui::Key::Z) {
+                debug!("Keyboard shortcut: Cmd/Ctrl+Shift+Z (Redo) - consumed before render");
                 return Some(false); // false = redo
             }
-            // Ctrl+Z: Undo
-            if i.consume_key(egui::Modifiers::CTRL, egui::Key::Z) {
-                debug!("Keyboard shortcut: Ctrl+Z (Undo) - consumed before render");
+            // Cmd+Z (macOS) / Ctrl+Z (Win/Linux): Undo
+            if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Z) {
+                debug!("Keyboard shortcut: Cmd/Ctrl+Z (Undo) - consumed before render");
                 return Some(true); // true = undo
             }
-            // Ctrl+Y: Redo
-            if i.consume_key(egui::Modifiers::CTRL, egui::Key::Y) {
-                debug!("Keyboard shortcut: Ctrl+Y (Redo) - consumed before render");
+            // Cmd+Y (macOS) / Ctrl+Y (Win/Linux): Redo
+            if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Y) {
+                debug!("Keyboard shortcut: Cmd/Ctrl+Y (Redo) - consumed before render");
                 return Some(false); // false = redo
             }
             None
@@ -3865,91 +3879,91 @@ impl FerriteApp {
     fn handle_keyboard_shortcuts(&mut self, ctx: &egui::Context) {
         ctx.input(|i| {
             // Ctrl+Shift+S: Save As (check first since it's more specific)
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::S) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::S) {
                 debug!("Keyboard shortcut: Ctrl+Shift+S (Save As)");
                 return Some(KeyboardAction::SaveAs);
             }
 
             // Ctrl+E: Toggle View Mode
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::E) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::E) {
                 debug!("Keyboard shortcut: Ctrl+E (Toggle View Mode)");
                 return Some(KeyboardAction::ToggleViewMode);
             }
 
             // Ctrl+Shift+T: Cycle Theme
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::T) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::T) {
                 debug!("Keyboard shortcut: Ctrl+Shift+T (Cycle Theme)");
                 return Some(KeyboardAction::CycleTheme);
             }
 
             // Ctrl+Shift+Tab: Previous tab
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Tab) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::Tab) {
                 debug!("Keyboard shortcut: Ctrl+Shift+Tab (Previous Tab)");
                 return Some(KeyboardAction::PrevTab);
             }
 
             // Ctrl+S: Save
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::S) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::S) {
                 debug!("Keyboard shortcut: Ctrl+S (Save)");
                 return Some(KeyboardAction::Save);
             }
 
             // Ctrl+O: Open
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::O) {
+            if i.modifiers.command && i.key_pressed(egui::Key::O) {
                 debug!("Keyboard shortcut: Ctrl+O (Open)");
                 return Some(KeyboardAction::Open);
             }
 
             // Ctrl+N: New file
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::N) {
+            if i.modifiers.command && i.key_pressed(egui::Key::N) {
                 debug!("Keyboard shortcut: Ctrl+N (New)");
                 return Some(KeyboardAction::New);
             }
 
             // Ctrl+T: New tab
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::T) {
+            if i.modifiers.command && i.key_pressed(egui::Key::T) {
                 debug!("Keyboard shortcut: Ctrl+T (New Tab)");
                 return Some(KeyboardAction::NewTab);
             }
 
             // Ctrl+W: Close current tab
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::W) {
+            if i.modifiers.command && i.key_pressed(egui::Key::W) {
                 debug!("Keyboard shortcut: Ctrl+W (Close Tab)");
                 return Some(KeyboardAction::CloseTab);
             }
 
             // Ctrl+Tab: Next tab
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::Tab) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::Tab) {
                 debug!("Keyboard shortcut: Ctrl+Tab (Next Tab)");
                 return Some(KeyboardAction::NextTab);
             }
 
             // Ctrl+,: Open settings
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::Comma) {
+            if i.modifiers.command && i.key_pressed(egui::Key::Comma) {
                 debug!("Keyboard shortcut: Ctrl+, (Open Settings)");
                 return Some(KeyboardAction::OpenSettings);
             }
 
             // Ctrl+F: Open find panel
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::F) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::F) {
                 debug!("Keyboard shortcut: Ctrl+F (Open Find)");
                 return Some(KeyboardAction::OpenFind);
             }
 
             // Ctrl+H: Open find and replace panel
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::H) {
+            if i.modifiers.command && i.key_pressed(egui::Key::H) {
                 debug!("Keyboard shortcut: Ctrl+H (Open Find/Replace)");
                 return Some(KeyboardAction::OpenFindReplace);
             }
 
             // Ctrl+G: Go to Line
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::G) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::G) {
                 debug!("Keyboard shortcut: Ctrl+G (Go to Line)");
                 return Some(KeyboardAction::GoToLine);
             }
 
             // Ctrl+Shift+D: Duplicate line or selection
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::D) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::D) {
                 debug!("Keyboard shortcut: Ctrl+Shift+D (Duplicate Line)");
                 return Some(KeyboardAction::DuplicateLine);
             }
@@ -3958,7 +3972,7 @@ impl FerriteApp {
             // BEFORE render to prevent TextEdit from processing the arrow keys.
 
             // Ctrl+D: Select next occurrence (multi-cursor)
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::D) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::D) {
                 debug!("Keyboard shortcut: Ctrl+D (Select Next Occurrence)");
                 return Some(KeyboardAction::SelectNextOccurrence);
             }
@@ -3988,7 +4002,7 @@ impl FerriteApp {
             }
 
             // Ctrl+Shift+L: Toggle Live Pipeline panel (JSON/YAML only)
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::L) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::L) {
                 debug!("Keyboard shortcut: Ctrl+Shift+L (Toggle Pipeline)");
                 return Some(KeyboardAction::TogglePipeline);
             }
@@ -3998,91 +4012,91 @@ impl FerriteApp {
             // ═══════════════════════════════════════════════════════════════════
 
             // Ctrl+Shift+B: Bullet list
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::B) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::B) {
                 debug!("Keyboard shortcut: Ctrl+Shift+B (Bullet List)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::BulletList));
             }
 
             // Ctrl+Shift+N: Numbered list
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::N) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::N) {
                 debug!("Keyboard shortcut: Ctrl+Shift+N (Numbered List)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::NumberedList));
             }
 
             // Ctrl+Shift+O: Toggle outline panel
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::O) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::O) {
                 debug!("Keyboard shortcut: Ctrl+Shift+O (Toggle Outline)");
                 return Some(KeyboardAction::ToggleOutline);
             }
 
             // Ctrl+B: Toggle file tree panel (when in workspace mode)
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::B) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::B) {
                 debug!("Keyboard shortcut: Ctrl+B (Toggle File Tree)");
                 return Some(KeyboardAction::ToggleFileTree);
             }
 
             // Ctrl+P: Quick file switcher (workspace mode only)
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::P) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::P) {
                 debug!("Keyboard shortcut: Ctrl+P (Quick Open)");
                 return Some(KeyboardAction::QuickOpen);
             }
 
             // Ctrl+Shift+F: Search in files (workspace mode only)
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::F) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::F) {
                 debug!("Keyboard shortcut: Ctrl+Shift+F (Search in Files)");
                 return Some(KeyboardAction::SearchInFiles);
             }
 
             // Ctrl+Shift+E: Export as HTML
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::E) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::E) {
                 debug!("Keyboard shortcut: Ctrl+Shift+E (Export HTML)");
                 return Some(KeyboardAction::ExportHtml);
             }
 
             // Ctrl+Shift+C: Code block
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::C) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::C) {
                 debug!("Keyboard shortcut: Ctrl+Shift+C (Code Block)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::CodeBlock));
             }
 
             // Ctrl+Shift+K: Image
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::K) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::K) {
                 debug!("Keyboard shortcut: Ctrl+Shift+K (Image)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::Image));
             }
 
             // Ctrl+B: Bold (must check after Ctrl+Shift+B)
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::B) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::B) {
                 debug!("Keyboard shortcut: Ctrl+B (Bold)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::Bold));
             }
 
             // Ctrl+I: Italic
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::I) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::I) {
                 debug!("Keyboard shortcut: Ctrl+I (Italic)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::Italic));
             }
 
             // Ctrl+K: Link (must check after Ctrl+Shift+K)
-            if i.modifiers.ctrl && !i.modifiers.shift && i.key_pressed(egui::Key::K) {
+            if i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::K) {
                 debug!("Keyboard shortcut: Ctrl+K (Link)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::Link));
             }
 
             // Ctrl+Q: Blockquote
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::Q) {
+            if i.modifiers.command && i.key_pressed(egui::Key::Q) {
                 debug!("Keyboard shortcut: Ctrl+Q (Blockquote)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::Blockquote));
             }
 
             // Ctrl+`: Inline code
-            if i.modifiers.ctrl && i.key_pressed(egui::Key::Backtick) {
+            if i.modifiers.command && i.key_pressed(egui::Key::Backtick) {
                 debug!("Keyboard shortcut: Ctrl+` (Inline Code)");
                 return Some(KeyboardAction::Format(MarkdownFormatCommand::InlineCode));
             }
 
             // Ctrl+1-6: Headings
-            if i.modifiers.ctrl && !i.modifiers.shift {
+            if i.modifiers.command && !i.modifiers.shift {
                 if i.key_pressed(egui::Key::Num1) {
                     debug!("Keyboard shortcut: Ctrl+1 (Heading 1)");
                     return Some(KeyboardAction::Format(MarkdownFormatCommand::Heading(1)));
@@ -4118,19 +4132,19 @@ impl FerriteApp {
 
             // Code Folding shortcuts
             // Ctrl+Shift+[: Fold all
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::OpenBracket) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::OpenBracket) {
                 debug!("Keyboard shortcut: Ctrl+Shift+[ (Fold All)");
                 return Some(KeyboardAction::FoldAll);
             }
 
             // Ctrl+Shift+]: Unfold all
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::CloseBracket) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::CloseBracket) {
                 debug!("Keyboard shortcut: Ctrl+Shift+] (Unfold All)");
                 return Some(KeyboardAction::UnfoldAll);
             }
 
             // Ctrl+Shift+.: Toggle fold at cursor
-            if i.modifiers.ctrl && i.modifiers.shift && i.key_pressed(egui::Key::Period) {
+            if i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::Period) {
                 debug!("Keyboard shortcut: Ctrl+Shift+. (Toggle Fold at Cursor)");
                 return Some(KeyboardAction::ToggleFoldAtCursor);
             }

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -6,6 +6,7 @@
 //! - Complete keyboard shortcuts reference
 //! - Credits and license information
 
+use crate::app::modifier_symbol;
 use eframe::egui::{self, Color32, RichText, ScrollArea, Ui};
 
 /// Keyboard shortcut category for organized display.
@@ -59,61 +60,62 @@ impl ShortcutCategory {
 
 /// A keyboard shortcut entry.
 struct Shortcut {
-    keys: &'static str,
+    keys: String,
     action: &'static str,
 }
 
 impl Shortcut {
-    const fn new(keys: &'static str, action: &'static str) -> Self {
-        Self { keys, action }
+    fn new(keys: impl Into<String>, action: &'static str) -> Self {
+        Self { keys: keys.into(), action }
     }
 }
 
 /// Get shortcuts for a given category.
 fn get_shortcuts(category: ShortcutCategory) -> Vec<Shortcut> {
+    let m = modifier_symbol();
     match category {
         ShortcutCategory::File => vec![
-            Shortcut::new("Ctrl+N", "New File"),
-            Shortcut::new("Ctrl+O", "Open File"),
-            Shortcut::new("Ctrl+S", "Save"),
-            Shortcut::new("Ctrl+Shift+S", "Save As"),
-            Shortcut::new("Ctrl+W", "Close Tab"),
+            Shortcut::new(format!("{}+N", m), "New File"),
+            Shortcut::new(format!("{}+O", m), "Open File"),
+            Shortcut::new(format!("{}+S", m), "Save"),
+            Shortcut::new(format!("{}+Shift+S", m), "Save As"),
+            Shortcut::new(format!("{}+W", m), "Close Tab"),
         ],
         ShortcutCategory::Edit => vec![
-            Shortcut::new("Ctrl+Z", "Undo"),
-            Shortcut::new("Ctrl+Y", "Redo"),
-            Shortcut::new("Ctrl+F", "Find"),
-            Shortcut::new("Ctrl+H", "Find & Replace"),
-            Shortcut::new("Ctrl+A", "Select All"),
-            Shortcut::new("Ctrl+C", "Copy"),
-            Shortcut::new("Ctrl+X", "Cut"),
-            Shortcut::new("Ctrl+V", "Paste"),
+            Shortcut::new(format!("{}+Z", m), "Undo"),
+            Shortcut::new(format!("{}+Y", m), "Redo"),
+            Shortcut::new(format!("{}+F", m), "Find"),
+            Shortcut::new(format!("{}+H", m), "Find & Replace"),
+            Shortcut::new(format!("{}+A", m), "Select All"),
+            Shortcut::new(format!("{}+C", m), "Copy"),
+            Shortcut::new(format!("{}+X", m), "Cut"),
+            Shortcut::new(format!("{}+V", m), "Paste"),
         ],
         ShortcutCategory::View => vec![
-            Shortcut::new("Ctrl+E", "Toggle Raw/Rendered"),
-            Shortcut::new("Ctrl+Shift+O", "Toggle Outline"),
-            Shortcut::new("Ctrl++", "Zoom In"),
-            Shortcut::new("Ctrl+-", "Zoom Out"),
-            Shortcut::new("Ctrl+0", "Reset Zoom"),
-            Shortcut::new("Ctrl+,", "Settings"),
+            Shortcut::new(format!("{}+E", m), "Toggle Raw/Rendered"),
+            Shortcut::new(format!("{}+Shift+O", m), "Toggle Outline"),
+            Shortcut::new(format!("{}++", m), "Zoom In"),
+            Shortcut::new(format!("{}+-", m), "Zoom Out"),
+            Shortcut::new(format!("{}+0", m), "Reset Zoom"),
+            Shortcut::new(format!("{}+,", m), "Settings"),
             Shortcut::new("F1", "About / Help"),
         ],
         ShortcutCategory::Formatting => vec![
-            Shortcut::new("Ctrl+B", "Bold"),
-            Shortcut::new("Ctrl+I", "Italic"),
-            Shortcut::new("Ctrl+U", "Underline"),
-            Shortcut::new("Ctrl+K", "Insert Link"),
-            Shortcut::new("Ctrl+`", "Inline Code"),
+            Shortcut::new(format!("{}+B", m), "Bold"),
+            Shortcut::new(format!("{}+I", m), "Italic"),
+            Shortcut::new(format!("{}+U", m), "Underline"),
+            Shortcut::new(format!("{}+K", m), "Insert Link"),
+            Shortcut::new(format!("{}+`", m), "Inline Code"),
         ],
         ShortcutCategory::Workspace => vec![
-            Shortcut::new("Ctrl+P", "Quick File Switcher"),
-            Shortcut::new("Ctrl+Shift+F", "Search in Files"),
-            Shortcut::new("Ctrl+Shift+E", "Toggle File Tree"),
+            Shortcut::new(format!("{}+P", m), "Quick File Switcher"),
+            Shortcut::new(format!("{}+Shift+F", m), "Search in Files"),
+            Shortcut::new(format!("{}+Shift+E", m), "Export HTML"),
         ],
         ShortcutCategory::Navigation => vec![
-            Shortcut::new("Ctrl+Tab", "Next Tab"),
-            Shortcut::new("Ctrl+Shift+Tab", "Previous Tab"),
-            Shortcut::new("Ctrl+G", "Go to Line"),
+            Shortcut::new(format!("{}+Tab", m), "Next Tab"),
+            Shortcut::new(format!("{}+Shift+Tab", m), "Previous Tab"),
+            Shortcut::new(format!("{}+G", m), "Go to Line"),
             Shortcut::new("F3", "Find Next"),
             Shortcut::new("Shift+F3", "Find Previous"),
         ],
@@ -445,7 +447,7 @@ impl AboutPanel {
                                             .inner_margin(egui::Margin::symmetric(6.0, 2.0))
                                             .show(ui, |ui| {
                                                 ui.label(
-                                                    RichText::new(shortcut.keys)
+                                                    RichText::new(&shortcut.keys)
                                                         .color(key_color)
                                                         .family(egui::FontFamily::Monospace)
                                                         .size(12.0),
@@ -502,7 +504,7 @@ mod tests {
     fn test_get_shortcuts_file() {
         let shortcuts = get_shortcuts(ShortcutCategory::File);
         assert!(!shortcuts.is_empty());
-        assert_eq!(shortcuts[0].keys, "Ctrl+N");
+        assert_eq!(shortcuts[0].keys, format!("{}+N", modifier_symbol()));
         assert_eq!(shortcuts[0].action, "New File");
     }
 

--- a/src/ui/ribbon.rs
+++ b/src/ui/ribbon.rs
@@ -5,6 +5,7 @@
 //!
 //! Design C: Streamlined ribbon with dropdowns, view controls moved to title bar.
 
+use crate::app::modifier_symbol;
 use crate::config::ViewMode;
 use crate::markdown::formatting::{FormattingState, MarkdownFormatCommand};
 use crate::state::FileType;
@@ -233,12 +234,12 @@ impl Ribbon {
             }
 
             // New file button
-            if icon_button(ui, "📄", "New (Ctrl+N)", true, is_dark).clicked() {
+            if icon_button(ui, "📄", &format!("New ({}+N)", modifier_symbol()), true, is_dark).clicked() {
                 action = Some(RibbonAction::New);
             }
 
             // Open file button
-            if icon_button(ui, "📂", "Open File (Ctrl+O)", true, is_dark).clicked() {
+            if icon_button(ui, "📂", &format!("Open File ({}+O)", modifier_symbol()), true, is_dark).clicked() {
                 action = Some(RibbonAction::Open);
             }
 
@@ -247,19 +248,19 @@ impl Ribbon {
                 if icon_button(ui, "📁", "Close Workspace", true, is_dark).clicked() {
                     action = Some(RibbonAction::CloseWorkspace);
                 }
-            } else if icon_button(ui, "📁", "Open Folder (Ctrl+Shift+O)", true, is_dark).clicked()
+            } else if icon_button(ui, "📁", &format!("Open Folder ({}+Shift+O)", modifier_symbol()), true, is_dark).clicked()
             {
                 action = Some(RibbonAction::OpenWorkspace);
             }
 
             // Workspace-only buttons: Search in Files and Quick File Switcher
             if is_workspace_mode {
-                if icon_button(ui, "🔎", "Search in Files (Ctrl+Shift+F)", true, is_dark).clicked()
+                if icon_button(ui, "🔎", &format!("Search in Files ({}+Shift+F)", modifier_symbol()), true, is_dark).clicked()
                 {
                     action = Some(RibbonAction::SearchInFiles);
                 }
 
-                if icon_button(ui, "⚡", "Quick File Switcher (Ctrl+P)", true, is_dark).clicked() {
+                if icon_button(ui, "⚡", &format!("Quick File Switcher ({}+P)", modifier_symbol()), true, is_dark).clicked() {
                     action = Some(RibbonAction::QuickFileSwitcher);
                 }
             }
@@ -272,14 +273,14 @@ impl Ribbon {
                 .show_ui(ui, |ui| {
                     if ui
                         .selectable_label(false, "💾 Save")
-                        .on_hover_text("Save (Ctrl+S)")
+                        .on_hover_text(format!("Save ({}+S)", modifier_symbol()))
                         .clicked()
                     {
                         action = Some(RibbonAction::Save);
                     }
                     if ui
                         .selectable_label(false, "📥 Save As...")
-                        .on_hover_text("Save As (Ctrl+Shift+S)")
+                        .on_hover_text(format!("Save As ({}+Shift+S)", modifier_symbol()))
                         .clicked()
                     {
                         action = Some(RibbonAction::SaveAs);
@@ -301,11 +302,11 @@ impl Ribbon {
                 );
             }
 
-            if icon_button(ui, "↩", "Undo (Ctrl+Z)", can_undo, is_dark).clicked() {
+            if icon_button(ui, "↩", &format!("Undo ({}+Z)", modifier_symbol()), can_undo, is_dark).clicked() {
                 action = Some(RibbonAction::Undo);
             }
 
-            if icon_button(ui, "↪", "Redo (Ctrl+Y)", can_redo, is_dark).clicked() {
+            if icon_button(ui, "↪", &format!("Redo ({}+Y)", modifier_symbol()), can_redo, is_dark).clicked() {
                 action = Some(RibbonAction::Redo);
             }
 
@@ -410,7 +411,7 @@ impl Ribbon {
                             let label = format!("Heading {}", level);
                             if ui
                                 .selectable_label(is_selected, &label)
-                                .on_hover_text(format!("Ctrl+{}", level))
+                                .on_hover_text(format!("{}+{}", modifier_symbol(), level))
                                 .clicked()
                             {
                                 action = Some(RibbonAction::Format(
@@ -524,7 +525,7 @@ impl Ribbon {
                     if icon_button(
                         ui,
                         "⚡",
-                        "Live Pipeline (Ctrl+Shift+L)\nPipe document through shell commands",
+                        &format!("Live Pipeline ({}+Shift+L)\nPipe document through shell commands", modifier_symbol()),
                         has_editor && pipeline_enabled,
                         is_dark,
                     )
@@ -552,28 +553,28 @@ impl Ribbon {
             }
 
             // Find/Replace (universal)
-            if icon_button(ui, "🔍", "Find/Replace (Ctrl+F)", true, is_dark).clicked() {
+            if icon_button(ui, "🔍", &format!("Find/Replace ({}+F)", modifier_symbol()), true, is_dark).clicked() {
                 action = Some(RibbonAction::FindReplace);
             }
 
             // Outline toggle
             let outline_icon = if outline_enabled { "📑" } else { "📋" };
-            let outline_tooltip = if file_type.is_markdown() {
+            let outline_tooltip: String = if file_type.is_markdown() {
                 if outline_enabled {
-                    "Hide Outline (Ctrl+Shift+O)"
+                    format!("Hide Outline ({}+Shift+O)", modifier_symbol())
                 } else {
-                    "Show Outline (Ctrl+Shift+O)"
+                    format!("Show Outline ({}+Shift+O)", modifier_symbol())
                 }
             } else if file_type.is_structured() {
                 if outline_enabled {
-                    "Hide Info Panel"
+                    "Hide Info Panel".to_string()
                 } else {
-                    "Show Info Panel"
+                    "Show Info Panel".to_string()
                 }
             } else {
-                "Toggle Outline"
+                "Toggle Outline".to_string()
             };
-            if icon_button(ui, outline_icon, outline_tooltip, true, is_dark).clicked() {
+            if icon_button(ui, outline_icon, &outline_tooltip, true, is_dark).clicked() {
                 action = Some(RibbonAction::ToggleOutline);
             }
 
@@ -593,7 +594,7 @@ impl Ribbon {
                     .show_ui(ui, |ui| {
                         if ui
                             .selectable_label(false, "🌐 Export as HTML")
-                            .on_hover_text("Export as HTML (Ctrl+Shift+E)")
+                            .on_hover_text(format!("Export as HTML ({}+Shift+E)", modifier_symbol()))
                             .clicked()
                         {
                             action = Some(RibbonAction::ExportHtml);


### PR DESCRIPTION
## Summary

- Change all keyboard shortcuts from `modifiers.ctrl` to `modifiers.command` which maps to Cmd on macOS and Ctrl on Windows/Linux
- Add `modifier_symbol()` helper function that returns "Cmd" or "Ctrl" based on the current platform
- Update About/Help panel and ribbon tooltips to show platform-appropriate shortcut keys

## Test plan

- [ ] On macOS: Verify shortcuts like Cmd+S, Cmd+N, Cmd+O work correctly
- [ ] On macOS: Verify Help panel shows "Cmd+S" not "Ctrl+S"
- [ ] On macOS: Verify ribbon tooltips show "Cmd+N" etc.
- [ ] On Windows/Linux: Verify Ctrl shortcuts still work as expected