### PR TITLE
fix: use dynamic modifier in debug log messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2899,7 +2899,8 @@ impl FerriteApp {
                             if let Some(click_pos) = editor_output.ctrl_click_pos {
                                 tab.add_cursor(click_pos);
                                 debug!(
-                                    "Ctrl+Click: added cursor at position {}, now {} cursor(s)",
+                                    "{}+Click: added cursor at position {}, now {} cursor(s)",
+                                    modifier_symbol(),
                                     click_pos,
                                     tab.cursor_count()
                                 );
@@ -4606,17 +4607,17 @@ impl FerriteApp {
         let consumed_action: Option<bool> = ctx.input_mut(|i| {
             // Cmd+Shift+Z (macOS) / Ctrl+Shift+Z (Win/Linux): Redo (check first since it's more specific)
             if i.consume_key(egui::Modifiers::COMMAND | egui::Modifiers::SHIFT, egui::Key::Z) {
-                debug!("Keyboard shortcut: Cmd/Ctrl+Shift+Z (Redo) - consumed before render");
+                debug!("Keyboard shortcut: {}+Shift+Z (Redo) - consumed before render", modifier_symbol());
                 return Some(false); // false = redo
             }
             // Cmd+Z (macOS) / Ctrl+Z (Win/Linux): Undo
             if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Z) {
-                debug!("Keyboard shortcut: Cmd/Ctrl+Z (Undo) - consumed before render");
+                debug!("Keyboard shortcut: {}+Z (Undo) - consumed before render", modifier_symbol());
                 return Some(true); // true = undo
             }
             // Cmd+Y (macOS) / Ctrl+Y (Win/Linux): Redo
             if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Y) {
-                debug!("Keyboard shortcut: Cmd/Ctrl+Y (Redo) - consumed before render");
+                debug!("Keyboard shortcut: {}+Y (Redo) - consumed before render", modifier_symbol());
                 return Some(false); // false = redo
             }
             None

--- a/src/ui/view_segment.rs
+++ b/src/ui/view_segment.rs
@@ -8,6 +8,7 @@
 #![allow(dead_code)]
 
 use crate::config::ViewMode;
+use crate::app::modifier_symbol;
 use crate::state::FileType;
 use eframe::egui::{self, Color32, Response, RichText, Sense, Vec2};
 
@@ -173,7 +174,7 @@ impl ViewModeSegment {
 
             // Tooltip
             let tooltip_text = if *enabled {
-                format!("{} (Ctrl+E to cycle)", tooltip)
+                format!("{} ({}+E to cycle)", tooltip, modifier_symbol())
             } else {
                 format!("{} (not available for this file type)", tooltip)
             };


### PR DESCRIPTION
## Summary
- Update debug log messages to use `modifier_symbol()` instead of hardcoded 'Ctrl' or 'Cmd/Ctrl' strings
- Ensures consistent platform-appropriate modifier display (Cmd on macOS, Ctrl elsewhere)

## Changes
- `src/app.rs`: 4 debug messages updated
- `src/ui/view_segment.rs`: 1 tooltip updated

## Test plan
- Build with `cargo build`
- Run on macOS and verify debug logs show 'Cmd' prefix
- Run on Linux/Windows and verify debug logs show 'Ctrl' prefix