### PR TITLE
Add official Nix flake build/dev workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,40 @@
+name: Nix
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "assets/**"
+      - "build.rs"
+      - ".github/workflows/nix.yml"
+
+jobs:
+  flake-check:
+    name: Flake check (x86_64-linux)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Verify package outputs for all supported systems
+        run: |
+          nix eval .#packages.x86_64-linux.ferrite.pname
+          nix eval .#packages.aarch64-linux.ferrite.pname
+          nix eval .#packages.x86_64-darwin.ferrite.pname
+          nix eval .#packages.aarch64-darwin.ferrite.pname
+
+      - name: Run flake checks
+        run: nix flake check --print-build-logs

--- a/README.md
+++ b/README.md
@@ -247,6 +247,27 @@ yay -Sy ferrite
 yay -Sy ferrite-bin
 ```
 
+#### Nix / NixOS (official flake)
+
+```bash
+# Run Ferrite directly from GitHub (no install)
+nix run github:OlaProeis/Ferrite
+
+# Drop into a shell that exposes ferrite in PATH
+nix shell github:OlaProeis/Ferrite
+```
+
+From a local clone:
+
+```bash
+# Build package output
+nix build .#ferrite
+./result/bin/ferrite
+
+# Enter development shell (Rust toolchain + system deps)
+nix develop
+```
+
 #### Other Linux (tar.gz)
 
 ```bash
@@ -263,6 +284,8 @@ tar -xzf ferrite-linux-x64.tar.gz
 
 - **Rust 1.70+** - Install from [rustup.rs](https://rustup.rs/)
 - **Platform-specific dependencies:**
+
+**Nix users:** you can skip manual dependency installation and use `nix develop` from the repository root (see `flake.nix`).
 
 **Windows:**
 - Visual Studio Build Tools 2019+ with C++ workload
@@ -492,6 +515,9 @@ cargo fmt
 cargo clippy
 cargo test
 cargo build
+
+# Optional (Nix users): validate flake outputs
+nix flake check
 
 # Commit and push
 git commit -m "feat: your feature description"

--- a/docs/building.md
+++ b/docs/building.md
@@ -92,6 +92,46 @@ cargo run --release
 
 ---
 
+## Nix / NixOS Workflow
+
+Ferrite now ships with an official `flake.nix` for reproducible build and dev flows.
+
+```bash
+# Run from upstream without installing
+nix run github:OlaProeis/Ferrite
+
+# Enter the project dev shell (Rust toolchain + platform deps)
+nix develop
+
+# Build package output from local checkout
+nix build .#ferrite
+./result/bin/ferrite
+```
+
+### Declarative usage on NixOS/Home Manager
+
+```nix
+{
+  inputs.ferrite.url = "github:OlaProeis/Ferrite";
+
+  outputs = { self, nixpkgs, ferrite, ... }: {
+    # NixOS example
+    nixosConfigurations.my-host = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        ({ pkgs, ... }: {
+          environment.systemPackages = [
+            ferrite.packages.${pkgs.system}.ferrite
+          ];
+        })
+      ];
+    };
+  };
+}
+```
+
+---
+
 ## Release Builds
 
 Release builds are optimized for size and performance. The `Cargo.toml` includes optimizations:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,103 @@
+{
+  description = "Ferrite - a fast, lightweight text editor";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          lib = pkgs.lib;
+          cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+
+          linuxBuildInputs = with pkgs; [
+            gtk3
+            libxkbcommon
+            wayland
+            vulkan-loader
+            libGL
+            libx11
+            libxcursor
+            libxi
+            libxrandr
+            libxcb
+          ];
+
+          darwinFrameworks = with pkgs.darwin.apple_sdk.frameworks; [
+            AppKit
+            Cocoa
+            CoreFoundation
+            CoreGraphics
+            CoreServices
+            Foundation
+            Metal
+            QuartzCore
+          ];
+
+          ferrite = pkgs.rustPlatform.buildRustPackage {
+            pname = "ferrite";
+            version = cargoToml.package.version;
+
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = [ pkgs.pkg-config ]
+              ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [ pkgs.wrapGAppsHook3 ];
+
+            buildInputs = lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxBuildInputs
+              ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin darwinFrameworks;
+
+            doCheck = false;
+
+            meta = with lib; {
+              description = "A fast, lightweight text editor for Markdown, JSON, and more";
+              homepage = "https://github.com/OlaProeis/Ferrite";
+              license = licenses.mit;
+              mainProgram = "ferrite";
+              platforms = platforms.linux ++ platforms.darwin;
+            };
+          };
+        in
+        {
+          packages = {
+            default = ferrite;
+            ferrite = ferrite;
+          };
+
+          apps.default = {
+            type = "app";
+            program = "${ferrite}/bin/ferrite";
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [
+              pkgs.rustc
+              pkgs.cargo
+              pkgs.rustfmt
+              pkgs.clippy
+              pkgs.rust-analyzer
+              pkgs.pkg-config
+            ]
+            ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux linuxBuildInputs
+            ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin darwinFrameworks;
+
+            shellHook = ''
+              echo "Ferrite Nix dev shell ready."
+              echo "Run cargo commands normally, e.g. cargo build --release"
+            '';
+          };
+
+          checks.default = ferrite;
+        }
+      );
+}


### PR DESCRIPTION
## Summary
This PR adds first-class Nix/NixOS support with minimal-risk changes focused on packaging and docs.

### What changed
- Added `flake.nix` with:
  - `packages.<system>.ferrite` + `packages.<system>.default`
  - `apps.<system>.default` for `nix run`
  - `devShells.<system>.default` with Rust toolchain + platform deps
  - support for `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`, `aarch64-darwin`
- Added `flake.lock` (pinned inputs)
- Added CI workflow `.github/workflows/nix.yml` to:
  - evaluate package outputs for all supported systems
  - run `nix flake check` on Linux
- Updated documentation:
  - `README.md`: Nix install/run/build/develop instructions
  - `docs/building.md`: dedicated Nix/NixOS workflow section and declarative usage example

## Validation
Executed locally:
- `nix --extra-experimental-features 'nix-command flakes' flake show`
- `nix --extra-experimental-features 'nix-command flakes' eval .#packages.x86_64-linux.ferrite.pname`
- `nix --extra-experimental-features 'nix-command flakes' eval .#packages.aarch64-linux.ferrite.pname`
- `nix --extra-experimental-features 'nix-command flakes' eval .#packages.x86_64-darwin.ferrite.pname`
- `nix --extra-experimental-features 'nix-command flakes' eval .#packages.aarch64-darwin.ferrite.pname`
- `nix --extra-experimental-features 'nix-command flakes' flake check --print-build-logs`
- `nix --extra-experimental-features 'nix-command flakes' develop --command cargo --version`

`flake check` successfully built Ferrite on Linux in this environment.

Closes #87
