### PR TITLE
docs: document Wayland keyboard workaround for Ubuntu 24.04 Gnome

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,29 @@ tar -xzf ferrite-linux-x64.tar.gz
 ./ferrite
 ```
 
+#### Known Issues
+
+**Keyboard not working on Ubuntu 24.04 LTS (GNOME/Wayland)**
+
+Keyboard input does not work when Ferrite is launched under GNOME on Wayland (Ubuntu 24.04 LTS and similar).
+As a workaround, launch Ferrite with `WAYLAND_DISPLAY` unset to force X11 mode:
+
+```bash
+WAYLAND_DISPLAY= ferrite
+```
+
+To make this permanent for your desktop launcher, create a user-level desktop entry override:
+
+```bash
+cp /usr/share/applications/ferrite-editor.desktop ~/.local/share/applications/ferrite-editor.desktop
+```
+
+Then edit `~/.local/share/applications/ferrite-editor.desktop` and change the `Exec` line to:
+
+```
+Exec=env -u WAYLAND_DISPLAY ferrite %F
+```
+
 </details>
 
 <details>


### PR DESCRIPTION

## Description

No keyboard input w/ ubuntu 24.04 LTS, wayland 1.22.0-2. Document the WAYLAND_DISPLAY= workaround and how to apply it permanently via the .desktop launcher

Ref #106

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes Made

Update the README.md




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Known Issues" section documenting keyboard input failure on Ubuntu 24.04 LTS with GNOME/Wayland environment.
  * Provided temporary and persistent workarounds for affected users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->