### PR TITLE
fix: scroll to document start/end on Ctrl+Home/End in Rendered view

### DIFF
--- a/src/markdown/editor.rs
+++ b/src/markdown/editor.rs
@@ -1062,16 +1062,59 @@ impl<'a> MarkdownEditor<'a> {
             });
         }
 
+        // Ctrl+Home / Ctrl+End: jump to document start/end in Rendered view.
+        // Inline TextEdits would otherwise consume these keys and only navigate
+        // within the focused block, which is not what users expect.
+        let (doc_jump_home, doc_jump_end) = ui.input(|i| {
+            if !i.modifiers.command {
+                return (false, false);
+            }
+            (i.key_pressed(Key::Home), i.key_pressed(Key::End))
+        });
+        let doc_edge_scroll: Option<f32> = if doc_jump_home {
+            Some(0.0)
+        } else if doc_jump_end {
+            // Use cached content height from the prior frame's culling state so we
+            // land precisely at the bottom. f32::INFINITY breaks egui's scrollbar
+            // math; a finite fallback gets clamped to the real max by egui.
+            let total_h: Option<f32> = ui.memory(|mem| {
+                mem.data
+                    .get_temp::<ViewportCullingState>(id.with("viewport_culling"))
+                    .map(|s| s.total_height)
+            });
+            Some(total_h.unwrap_or(1.0e9))
+        } else {
+            None
+        };
+        if doc_edge_scroll.is_some() {
+            ui.input_mut(|i| {
+                i.events.retain(|e| {
+                    !matches!(
+                        e,
+                        egui::Event::Key {
+                            key: Key::Home | Key::End,
+                            pressed: true,
+                            modifiers,
+                            ..
+                        } if modifiers.command
+                    )
+                });
+            });
+        }
+
         // Render the document in a scroll area
         let mut scroll_area = ScrollArea::vertical()
             .id_salt(id.with("rendered_scroll"))
             .auto_shrink([false, false]);
 
         // Priority order for scroll offset:
+        // 0. Ctrl+Home / Ctrl+End (highest — explicit user navigation)
         // 1. Nav button scroll (from previous frame)
         // 2. Pending scroll offset from mode switch
         // 3. Target scroll offset from outline navigation
-        if let Some(offset) = pending_nav_scroll {
+        if let Some(offset) = doc_edge_scroll {
+            scroll_area = scroll_area.vertical_scroll_offset(offset);
+        } else if let Some(offset) = pending_nav_scroll {
             scroll_area = scroll_area.vertical_scroll_offset(offset);
             log::debug!(
                 "Applied nav button scroll offset in rendered mode: {}",


### PR DESCRIPTION
## Description

In Rendered view, each markdown block (paragraph, heading, list item, etc.) is rendered as an inline `TextEdit`. When focus is inside one of those widgets, **Ctrl+Home** and **Ctrl+End** are consumed by the inner `TextEdit` and move the cursor to the start/end of that single block — not to the start/end of the document, as users expect.

This PR intercepts those keys at the `ScrollArea` level — before the inner `TextEdit`s see them — and applies the appropriate `vertical_scroll_offset`.

Raw view was already correct (handled in `src/editor/ferrite/input/keyboard.rs`), so this only touches the Rendered/Split path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Changes Made

- Detect `Ctrl+Home` / `Ctrl+End` in `MarkdownEditor::show_rendered_editor` (in `src/markdown/editor.rs`) **before** the `ScrollArea` is built.
- For `Ctrl+Home`: set `vertical_scroll_offset(0.0)`.
- For `Ctrl+End`: read the cached `total_height` from the prior frame's `ViewportCullingState` (falls back to a large finite value on the first frame). `f32::INFINITY` was tried first but broke egui's scrollbar arithmetic — content area collapsed and the scrollbar disappeared — so a finite value (clamped by egui) is used instead.
- Remove the matching `Key::Home` / `Key::End` events from the input queue so the focused `TextEdit` doesn't also navigate within its block.
- Place this as the highest-priority source in the existing scroll-offset chain (above nav-button scroll, mode-switch pending scroll, and outline-navigation scroll).

## Checklist

- [x] My code follows the project's code style
- [x] I have run `cargo fmt` and it produces no changes *to the lines this PR touches* (pre-existing trailing-whitespace findings elsewhere in the tree are not addressed here to keep the diff focused).
- [x] I have run `cargo clippy` — no new warnings from this change (the existing 471 pre-existing warnings in the tree are unchanged).
- [x] I have run `cargo test` and all tests pass (1477 passed, 0 failed, 2 ignored).
- [x] I have run `cargo build --release` successfully.
- [ ] I have updated documentation if needed (no docs changes needed — this is a UX fix to match standard editor behavior).
- [ ] I have added tests for new functionality (no automated tests added — the behavior is a `ScrollArea` interaction that's hard to assert without a UI harness; verified manually as described below).
- [x] My changes generate no new warnings

## Testing

Verified manually on Windows 10 with a `cargo build --release` build:

1. Open a long markdown file (multiple screens of content).
2. Switch to **Rendered** view.
3. Scroll to the middle of the document.
4. Press **Ctrl+Home** → view scrolls to the very top. ✓
5. Press **Ctrl+End** → view scrolls to the very bottom; scrollbar remains correct. ✓
6. Repeat in **Split** view (right pane uses the same `EditorMode::Rendered` path) → works. ✓
7. **Raw** view unchanged (it was already correct via `src/editor/ferrite/input/keyboard.rs`). ✓
8. With focus inside an inline editable block in Rendered view: the keys still navigate the document instead of the block. ✓

## Additional Notes

- One small edge: if `Ctrl+End` is pressed on the very first frame after opening a file (before `ViewportCullingState` has measured any blocks), the scroll uses the `1.0e9` fallback. egui clamps this to the actual max scroll position, but if the culling state hasn't measured everything yet, the bottom may be approximate; a second press lands precisely. In practice this is hard to hit — by the time a user can press a shortcut, at least one render frame has measured the culling state. Happy to add a `request_repaint` + second-frame application if reviewers prefer a stricter guarantee.
- I considered promoting this to an app-level `ShortcutCommand` so it would be user-configurable from the settings UI, but that adds more surface area for what is essentially a fix to match expected behavior. Open to that direction if the maintainer prefers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ctrl+Home and Ctrl+End keyboard shortcuts in rendered editor mode to properly jump to the document start and end.
  * Improved keyboard event handling to prevent navigation shortcuts from being intercepted by text editing widgets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OlaProeis/Ferrite/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->