### PR TITLE
fix(single-instance): improve Windows foreground activation

### DIFF
--- a/docs/technical/platform/single-instance.md
+++ b/docs/technical/platform/single-instance.md
@@ -2,16 +2,17 @@
 
 ## Overview
 
-Ensures only one Ferrite window runs at a time. When a second instance is launched (e.g., double-clicking a file in Windows Explorer), it forwards file paths to the already-running instance via local TCP, which opens them as tabs. The second process then exits immediately.
+Ensures only one Ferrite window runs at a time. When a second instance is launched (e.g., double-clicking a file in Windows Explorer), it forwards file paths to the already-running instance via local TCP, which opens them as tabs. On Windows, the secondary process also grants the primary process foreground permission before exiting so the existing window can be raised more reliably.
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
-| `src/single_instance.rs` | Protocol implementation: lock file, TCP client, background accept thread, channel-based path delivery |
+| `src/single_instance.rs` | Protocol implementation: lock file, pid file, TCP client, background accept thread, channel-based path delivery |
 | `src/main.rs` | Instance check **early** in startup (before config/icon loading) via `try_acquire_instance` |
 | `src/app/mod.rs` | Stores `SingleInstanceListener`, provides egui context for repaint wakeup |
 | `src/app/file_ops.rs` | `handle_instance_paths()` — drains channel and opens received paths as tabs |
+| `src/platform/mod.rs` | Windows foreground-permission helper for Explorer-launched secondary processes |
 
 ## Architecture
 
@@ -27,11 +28,14 @@ Secondary instance                 Primary instance
    ↓                              Connection arrives!
  TCP connect(port)  ───────────→  Read paths from stream
    ↓                                     ↓
- Write paths + shutdown(Write)    Send paths via mpsc channel
+ AllowSetForegroundWindow(pid)    Send paths via mpsc channel
+ Write paths + shutdown(Write)             ↓
    ↓                                     ↓
  Exit process                     ctx.request_repaint() ← wakes UI
                                          ↓
                                   UI thread: poll() drains channel
+                                         ↓
+                                  Focus + attention request
                                          ↓
                                   Open file as tab (instant)
 ```
@@ -43,31 +47,38 @@ Secondary instance                 Primary instance
    - Linux: `~/.config/ferrite/instance.lock`
    - macOS: `~/Library/Application Support/ferrite/instance.lock`
 
-2. **Startup flow** (runs early, before config/logging/icon loading):
+2. **PID file**: `{config_dir}/instance.pid` stores the primary process ID
+   - Used on Windows so the Explorer-launched secondary process can call `AllowSetForegroundWindow(primary_pid)` before exiting
+
+3. **Startup flow** (runs early, before config/logging/icon loading):
    ```
    Parse CLI args → Read lock file → port exists?
      YES → connect to port (500ms timeout)
-       SUCCESS → send paths, shutdown(Write), exit
+       SUCCESS → (Windows: allow foreground for primary PID) → send paths, shutdown(Write), exit
        FAIL → stale lock, delete, become primary
      NO → become primary
    ```
 
-3. **Primary instance**:
+4. **Primary instance**:
    - Binds `TcpListener` on `127.0.0.1:0` (OS picks port)
    - Writes port to lock file
+   - Writes `std::process::id()` to `instance.pid`
    - Spawns background thread (`single-instance-accept`) that blocks on `accept()`
    - Accepted connections are read with 100ms timeout (localhost data arrives in <1ms)
    - Paths sent to UI via `mpsc::channel`; UI woken via `ctx.request_repaint()`
-   - UI thread drains channel with `try_recv()` (non-blocking, nanoseconds)
+   - UI thread drains channel with `try_recv()` (non-blocking, nanoseconds), then issues:
+     - `ViewportCommand::Focus`
+     - `ViewportCommand::RequestUserAttention(Informational)`
 
-4. **Secondary instance** (exits in <100ms):
+5. **Secondary instance** (exits in <100ms):
    - Connects to `127.0.0.1:{port}` with 500ms timeout
+   - On Windows, reads `instance.pid` and calls `AllowSetForegroundWindow(primary_pid)` before exit
    - Sends file paths as UTF-8 lines (one per line)
    - Sends `__FOCUS__` if no paths (just bring window forward)
    - Calls `stream.shutdown(Write)` to send FIN immediately
    - Exits cleanly via `return Ok(())`
 
-5. **Cleanup**: Lock file removed on `Drop` of `SingleInstanceListener`
+6. **Cleanup**: Lock file and pid file removed on `Drop` of `SingleInstanceListener`
 
 ## Performance Design
 
@@ -76,6 +87,7 @@ The protocol is designed for instant response (<50ms end-to-end):
 | Component | Technique | Latency |
 |-----------|-----------|---------|
 | Secondary startup | Single-instance check runs before config/logging/icon loading | ~50ms |
+| Windows foreground handoff | Secondary process grants foreground permission to primary | ~0ms |
 | TCP delivery | Explicit `shutdown(Write)` sends EOF immediately | <1ms |
 | Primary accept | Dedicated blocking thread, no polling delay | <1ms |
 | UI wakeup | `ctx.request_repaint()` from background thread bypasses idle intervals | <1ms |
@@ -88,6 +100,7 @@ Previously, the protocol used per-frame polling of a non-blocking listener on th
 | Scenario | Behavior |
 |----------|----------|
 | Stale lock (crashed instance) | TCP connect fails → lock deleted → new primary |
+| Stale pid file | Ignored if unreadable; focus falls back to viewport commands only |
 | No paths (bare launch) | `__FOCUS__` signal sent → existing window focused |
 | Config dir unavailable | Warning logged, app runs without single-instance |
 | Listener bind failure | App runs normally, just no IPC |
@@ -99,9 +112,10 @@ Previously, the protocol used per-frame polling of a non-blocking listener on th
 
 - Background thread provides repaint context via `Arc<Mutex<Option<egui::Context>>>`
 - `handle_instance_paths()` calls `set_repaint_ctx()` each frame (cheap when already set)
-- Uses `ViewportCommand::Focus` to bring window to front
+- Uses `ViewportCommand::Focus` plus `ViewportCommand::RequestUserAttention(Informational)` when external paths arrive
+- Uses `instance.pid` + `AllowSetForegroundWindow` on Windows so Explorer-launched secondary processes can transfer foreground rights to the primary window
 - Reuses `state.open_file()` and `state.open_workspace()` for consistent behavior
-- Lock file stored in same config directory as other Ferrite config (`get_config_dir()`)
+- Lock and pid files are stored in the same config directory as other Ferrite config (`get_config_dir()`)
 
 ## No New Dependencies
 

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -1489,8 +1489,11 @@ impl FerriteApp {
 
         info!("Received {} path(s) from secondary instance", paths.len());
 
-        // Bring this window to the front
+        // Keep the normal cross-platform focus path in place.
         ctx.send_viewport_cmd(egui::ViewportCommand::Focus);
+        ctx.send_viewport_cmd(egui::ViewportCommand::RequestUserAttention(
+            egui::UserAttentionType::Informational,
+        ));
 
         let time = self.get_app_time();
         let mut opened = 0;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -10,3 +10,17 @@ pub use macos::get_open_file_paths;
 pub fn get_open_file_paths() -> Vec<std::path::PathBuf> {
     Vec::new()
 }
+
+#[cfg(target_os = "windows")]
+pub fn allow_set_foreground_window(process_id: u32) -> bool {
+    extern "system" {
+        fn AllowSetForegroundWindow(dw_process_id: u32) -> i32;
+    }
+
+    unsafe { AllowSetForegroundWindow(process_id) != 0 }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn allow_set_foreground_window(_process_id: u32) -> bool {
+    false
+}

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -23,6 +23,8 @@ use std::sync::{mpsc, Arc, Mutex};
 
 /// Name of the lock file stored in the config directory.
 const LOCK_FILE_NAME: &str = "instance.lock";
+/// Name of the pid file stored next to the lock file.
+const PID_FILE_NAME: &str = "instance.pid";
 
 /// Timeout for connecting to the existing instance (milliseconds).
 const CONNECT_TIMEOUT_MS: u64 = 500;
@@ -75,6 +77,9 @@ fn create_listener() -> Option<SingleInstanceListener> {
 
     if let Err(e) = write_lock_file(port) {
         warn!("Failed to write instance lock file: {}", e);
+    }
+    if let Err(e) = write_pid_file(std::process::id()) {
+        warn!("Failed to write instance pid file: {}", e);
     }
 
     info!("Single-instance listener started on port {}", port);
@@ -176,6 +181,7 @@ fn try_forward_paths(port: u16, paths: &[PathBuf]) -> bool {
     };
 
     let _ = stream.set_write_timeout(Some(Duration::from_secs(2)));
+    allow_primary_foreground_from_secondary();
 
     for path in paths {
         let line = format!("{}\n", path.display());
@@ -208,9 +214,38 @@ fn write_lock_file(port: u16) -> std::io::Result<()> {
     std::fs::write(&lock_path, port.to_string())
 }
 
+fn write_pid_file(pid: u32) -> std::io::Result<()> {
+    let pid_path = get_pid_file_path().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::NotFound, "Config dir not available")
+    })?;
+
+    if let Some(parent) = pid_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    std::fs::write(&pid_path, pid.to_string())
+}
+
 /// Get the path to the instance lock file.
 fn get_lock_file_path() -> Option<PathBuf> {
     get_config_dir().ok().map(|dir| dir.join(LOCK_FILE_NAME))
+}
+
+fn get_pid_file_path() -> Option<PathBuf> {
+    get_config_dir().ok().map(|dir| dir.join(PID_FILE_NAME))
+}
+
+fn read_primary_pid() -> Option<u32> {
+    let pid_path = get_pid_file_path()?;
+    let content = std::fs::read_to_string(pid_path).ok()?;
+    content.trim().parse::<u32>().ok()
+}
+
+fn allow_primary_foreground_from_secondary() {
+    #[cfg(target_os = "windows")]
+    if let Some(primary_pid) = read_primary_pid() {
+        let _ = crate::platform::allow_set_foreground_window(primary_pid);
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -265,6 +300,12 @@ impl Drop for SingleInstanceListener {
             if lock_path.exists() {
                 debug!("Cleaning up instance lock file");
                 let _ = std::fs::remove_file(&lock_path);
+            }
+        }
+        if let Some(pid_path) = get_pid_file_path() {
+            if pid_path.exists() {
+                debug!("Cleaning up instance pid file");
+                let _ = std::fs::remove_file(&pid_path);
             }
         }
     }


### PR DESCRIPTION
## Summary
- pass the secondary process PID through the single-instance activation channel
- allow Windows foreground activation before issuing the existing viewport focus request
- request user attention as a fallback when opening files from Explorer into an existing window

## Problem
Ferrite already uses `ViewportCommand::Focus` when paths arrive from the single-instance TCP listener, but on Windows that is not always enough when the window is already running in the background and the user double-clicks a file from Explorer.

## Change
- keep the existing cross-platform `ViewportCommand::Focus`
- send `__PID__:<pid>` from the secondary process
- call `AllowSetForegroundWindow(sender_pid)` on Windows before the focus request
- also send `ViewportCommand::RequestUserAttention(Informational)` as a fallback

Fixes #147

## Validation
- `cargo check --message-format short`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced window management when launching multiple instances of the application. Secondary instances now properly request focus and user attention when bringing existing windows to the foreground, providing more reliable behavior across platforms.

* **Documentation**
  * Updated technical documentation to describe the single-instance protocol implementation and cross-platform window-foreground handoff mechanics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->