### PR TITLE
ci: provision linux webview dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libxcb-shape0-dev libxcb-xfixes0-dev libfontconfig1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libxcb-shape0-dev libxcb-xfixes0-dev libfontconfig1-dev
 
       - name: Install Rust (MSRV from rust-toolchain.toml)
         uses: dtolnay/rust-toolchain@1.92.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libxcb-shape0-dev libxcb-xfixes0-dev libfontconfig1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libxcb-shape0-dev libxcb-xfixes0-dev libfontconfig1-dev
 
       - name: Install Rust (MSRV from rust-toolchain.toml)
         uses: dtolnay/rust-toolchain@1.92.0

--- a/flake.nix
+++ b/flake.nix
@@ -22,8 +22,10 @@
 
           linuxBuildInputs = with pkgs; [
             gtk3
+            libsoup_3
             libxkbcommon
             wayland
+            webkitgtk_4_1
             vulkan-loader
             libGL
             libx11


### PR DESCRIPTION
This keeps PR #155 narrow by moving the Linux/Nix baseline blocker into its own packaging-only slice.

## What changed
- add `libwebkit2gtk-4.1-dev` and `libsoup-3.0-dev` to the Linux dependency install step in `.github/workflows/ci.yml`
- add the same Ubuntu packages to `.github/workflows/release.yml`
- add `webkitgtk_4_1` and `libsoup_3` to `linuxBuildInputs` in `flake.nix`

## Why
The experimental branch now pulls `wry`, and the current Linux/Nix failures are not caused by the mermaid + video_embed changes in PR #155. CI is currently blocked earlier by missing WebKit/libsoup provisioning.

## Validation
- `git diff --check`
- reviewed the failed CI logs for PR #155 (`Test (Linux)` and `Flake check (x86_64-linux)`)

## Out of scope
- `src/markdown/video_embed.rs`
- `src/markdown/mermaid/flowchart/layout/mod.rs`
- Windows `vcs::git::tests::test_git_service_untracked_file`
