### PR TITLE
feat: open local markdown links in file manager

### DIFF
--- a/src/app/central_panel.rs
+++ b/src/app/central_panel.rs
@@ -17,6 +17,7 @@ use crate::markdown::{
     push_video_webview_render_slot, rendered_editor_id, CodeExecutionUi, CsvViewer, EditorMode,
     MarkdownEditor, TreeViewer, VideoWebViewParent, WikilinkContext,
 };
+use crate::path_utils::open_in_file_manager;
 use crate::preview::{ScrollOrigin, SyncScrollState};
 use crate::state::{OpenResult, SpecialTabKind, TabContent, TabKind};
 use crate::theme::ThemeColors;
@@ -790,7 +791,7 @@ impl FerriteApp {
                 }
 
                 if let Some(path) = tab_context_reveal_path {
-                    if let Err(e) = open::that(&path) {
+                    if let Err(e) = open_in_file_manager(&path) {
                         warn!("Failed to reveal tab in explorer: {}", e);
                         self.state
                             .show_error(t!("error.explorer_failed", error = e.to_string()).to_string());

--- a/src/app/file_ops.rs
+++ b/src/app/file_ops.rs
@@ -11,6 +11,7 @@ use crate::files::dialogs::{
     open_folder_dialog, open_multiple_files_dialog, portal_install_instructions, save_file_dialog,
     DialogResult,
 };
+use crate::path_utils::open_in_file_manager;
 use crate::state::{
     complete_external_file_open, is_external_open_extension, FileType, OpenResult,
 };
@@ -2002,7 +2003,7 @@ impl FerriteApp {
                     path.parent().map(|p| p.to_path_buf()).unwrap_or(path)
                 };
 
-                if let Err(e) = open::that(&folder) {
+                if let Err(e) = open_in_file_manager(&folder) {
                     warn!("Failed to reveal in explorer: {}", e);
                     self.state
                         .show_error(t!("error.explorer_failed", error = e.to_string()).to_string());

--- a/src/markdown/editor.rs
+++ b/src/markdown/editor.rs
@@ -66,6 +66,7 @@ use crate::markdown::widgets::{
     CodeBlockData, EditableCodeBlock, EditableTable, MermaidBlock, MermaidBlockData,
     RenderedLinkState, RenderedLinkWidget, TableData, TableEditState, WidgetColors,
 };
+use crate::path_utils::resolve_local_link_path;
 use crate::ui::{render_nav_buttons, NavAction};
 use eframe::egui::{
     self, Color32, ColorImage, FontId, Key, Margin, Response, RichText, ScrollArea, Stroke,
@@ -6029,12 +6030,20 @@ fn render_link(
             })
             .clone()
     });
+    let link_ctx = ui.memory(|mem| {
+        mem.data
+            .get_temp::<WikilinkContext>(egui::Id::new("wikilink_resolution_context"))
+    });
 
     // Create and show the rendered link widget
     let output = RenderedLinkWidget::new(&mut link_state, title)
         .font_size(font_size)
         .colors(widget_colors)
         .id(link_id)
+        .resolution_context(
+            link_ctx.as_ref().and_then(|ctx| ctx.current_dir.clone()),
+            link_ctx.as_ref().and_then(|ctx| ctx.workspace_root.clone()),
+        )
         .show(ui);
 
     // Update stored state
@@ -6263,40 +6272,8 @@ fn resolve_image_path(
     }
 
     // Skip web URLs â€” we only support local images
-    if url.starts_with("http://") || url.starts_with("https://") || url.starts_with("data:") {
-        return None;
-    }
-
-    // Strip leading file:// protocol if present
-    let path_str = url.strip_prefix("file://").unwrap_or(url);
-
-    let path = Path::new(path_str);
-
-    // If absolute path, use directly
-    if path.is_absolute() {
-        if path.is_file() {
-            return Some(path.to_path_buf());
-        }
-        return None;
-    }
-
-    // Resolve relative to current document directory
-    if let Some(dir) = current_dir {
-        let resolved = dir.join(path_str);
-        if resolved.is_file() {
-            return Some(resolved);
-        }
-    }
-
-    // Fall back to workspace root
-    if let Some(root) = workspace_root {
-        let resolved = root.join(path_str);
-        if resolved.is_file() {
-            return Some(resolved);
-        }
-    }
-
-    None
+    let resolved = resolve_local_link_path(url, current_dir, workspace_root)?;
+    resolved.is_file().then_some(resolved)
 }
 
 /// Load an image from disk, decode it, and create an egui texture.

--- a/src/markdown/widgets.rs
+++ b/src/markdown/widgets.rs
@@ -23,6 +23,9 @@ use crate::markdown::code_execution::{
 use crate::markdown::parser::{
     CalloutType, HeadingLevel, ListType, MarkdownNode, MarkdownNodeType, TableAlignment,
 };
+use crate::path_utils::{
+    open_in_file_manager, resolve_openable_link_target, OpenableLinkTarget,
+};
 use crate::terminal::TerminalTheme;
 use crate::ui::phosphor_icons::{
     phosphor_rich_text, ARROWS_CLOCKWISE, ARROWS_LEFT_RIGHT, BUILDINGS, CALENDAR, CARET_DOWN,
@@ -4596,6 +4599,10 @@ pub struct RenderedLinkWidget<'a> {
     colors: Option<WidgetColors>,
     /// Unique ID for this link
     id: Option<egui::Id>,
+    /// Current file directory for resolving relative local links.
+    current_dir: Option<std::path::PathBuf>,
+    /// Workspace root for resolving relative local links.
+    workspace_root: Option<std::path::PathBuf>,
 }
 
 impl<'a> RenderedLinkWidget<'a> {
@@ -4607,6 +4614,8 @@ impl<'a> RenderedLinkWidget<'a> {
             font_size: 14.0,
             colors: None,
             id: None,
+            current_dir: None,
+            workspace_root: None,
         }
     }
 
@@ -4631,11 +4640,25 @@ impl<'a> RenderedLinkWidget<'a> {
         self
     }
 
+    /// Provide path resolution context for local markdown links.
+    #[must_use]
+    pub fn resolution_context(
+        mut self,
+        current_dir: Option<std::path::PathBuf>,
+        workspace_root: Option<std::path::PathBuf>,
+    ) -> Self {
+        self.current_dir = current_dir;
+        self.workspace_root = workspace_root;
+        self
+    }
+
     /// Show the link widget and return the output.
     pub fn show(self, ui: &mut Ui) -> RenderedLinkOutput {
         let colors = self
             .colors
             .unwrap_or_else(|| WidgetColors::resolved(ui, Theme::System));
+        let current_dir = self.current_dir.as_deref();
+        let workspace_root = self.workspace_root.as_deref();
 
         let link_id = self.id.expect("RenderedLinkWidget requires an explicit ID");
 
@@ -4683,34 +4706,31 @@ impl<'a> RenderedLinkWidget<'a> {
 
         // Track whether we consumed a click (to prevent parent from entering edit mode)
         let mut click_consumed = false;
+        let open_target =
+            resolve_openable_link_target(&self.state.edit_url, current_dir, workspace_root);
 
         // Handle click interactions
-        // Check for middle-click first (always opens in browser)
+        // Check for middle-click first (always opens the target directly)
         if link_response.middle_clicked() {
             click_consumed = true;
-            let can_open = self.state.edit_url.starts_with("http://")
-                || self.state.edit_url.starts_with("https://");
-            if can_open {
-                if let Err(e) = open::that(&self.state.edit_url) {
-                    log::error!("Failed to open URL: {}", e);
+            if let Some(target) = open_target.as_ref() {
+                if let Err(e) = open_link_target(target) {
+                    log::error!("Failed to open link target: {}", e);
                 } else {
-                    log::debug!("Opened URL via middle-click: {}", self.state.edit_url);
+                    log::debug!("Opened link target via middle-click: {:?}", target);
                 }
             }
         } else if clicked_on_link {
             click_consumed = true;
             // Check if Ctrl/Cmd was held during the click
-            let open_in_browser = modifiers.ctrl || modifiers.command;
+            let open_directly = modifiers.ctrl || modifiers.command;
 
-            if open_in_browser {
-                // Ctrl+Click / Cmd+Click: Open URL in default browser
-                let can_open = self.state.edit_url.starts_with("http://")
-                    || self.state.edit_url.starts_with("https://");
-                if can_open {
-                    if let Err(e) = open::that(&self.state.edit_url) {
-                        log::error!("Failed to open URL: {}", e);
+            if open_directly {
+                if let Some(target) = open_target.as_ref() {
+                    if let Err(e) = open_link_target(target) {
+                        log::error!("Failed to open link target: {}", e);
                     } else {
-                        log::debug!("Opened URL via Ctrl+Click: {}", self.state.edit_url);
+                        log::debug!("Opened link target via modifier-click: {:?}", target);
                     }
                 }
             } else {
@@ -4721,15 +4741,16 @@ impl<'a> RenderedLinkWidget<'a> {
 
         // Show tooltip with URL and interaction hint when hovering (if popup not open)
         if link_response.hovered() && !self.state.popup_open {
-            let can_open = self.state.edit_url.starts_with("http://")
-                || self.state.edit_url.starts_with("https://");
-            let tooltip = if can_open {
-                format!(
+            let tooltip = match open_target.as_ref() {
+                Some(OpenableLinkTarget::WebUrl(_)) => format!(
                     "{}\n\nClick to edit • Ctrl+Click to open in browser",
                     self.state.edit_url
-                )
-            } else {
-                format!("{}\n\nClick to edit", self.state.edit_url)
+                ),
+                Some(OpenableLinkTarget::LocalPath(_)) => format!(
+                    "{}\n\nClick to edit • Ctrl+Click to reveal in file manager",
+                    self.state.edit_url
+                ),
+                None => format!("{}\n\nClick to edit", self.state.edit_url),
             };
             link_response.on_hover_text(tooltip);
         }
@@ -4818,12 +4839,14 @@ impl<'a> RenderedLinkWidget<'a> {
 
                             // Action buttons
                             ui.horizontal(|ui| {
-                                // Open Link button
-                                let can_open = self.state.edit_url.starts_with("http://")
-                                    || self.state.edit_url.starts_with("https://");
+                                let popup_open_target = resolve_openable_link_target(
+                                    &self.state.edit_url,
+                                    current_dir,
+                                    workspace_root,
+                                );
 
                                 let open_button = ui.add_enabled(
-                                    can_open,
+                                    popup_open_target.is_some(),
                                     egui::Button::new(t!("widgets.link.open").to_string()),
                                 );
 
@@ -4831,18 +4854,22 @@ impl<'a> RenderedLinkWidget<'a> {
                                 let open_clicked = open_button.clicked();
 
                                 // Show appropriate hover text
-                                let hover_text = if can_open {
-                                    "Open URL in browser"
-                                } else {
-                                    "Only http/https URLs can be opened"
+                                let hover_text = match popup_open_target.as_ref() {
+                                    Some(OpenableLinkTarget::WebUrl(_)) => "Open URL in browser",
+                                    Some(OpenableLinkTarget::LocalPath(_)) => {
+                                        "Reveal path in file manager"
+                                    }
+                                    None => "Only resolvable web or local paths can be opened",
                                 };
                                 open_button.on_hover_text(hover_text);
 
-                                if open_clicked && can_open {
-                                    if let Err(e) = open::that(&self.state.edit_url) {
-                                        log::error!("Failed to open URL: {}", e);
-                                    } else {
-                                        log::debug!("Opened URL: {}", self.state.edit_url);
+                                if open_clicked {
+                                    if let Some(target) = popup_open_target.as_ref() {
+                                        if let Err(e) = open_link_target(target) {
+                                            log::error!("Failed to open link target: {}", e);
+                                        } else {
+                                            log::debug!("Opened link target from popup: {:?}", target);
+                                        }
                                     }
                                 }
 
@@ -4893,6 +4920,13 @@ impl<'a> RenderedLinkWidget<'a> {
             is_autolink,
             click_consumed,
         }
+    }
+}
+
+fn open_link_target(target: &OpenableLinkTarget) -> std::io::Result<()> {
+    match target {
+        OpenableLinkTarget::WebUrl(url) => open::that(url),
+        OpenableLinkTarget::LocalPath(path) => open_in_file_manager(path),
     }
 }
 

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -28,6 +28,15 @@
 
 use std::path::{Path, PathBuf};
 
+/// A link target that Ferrite can open directly from rendered markdown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenableLinkTarget {
+    /// Open in the default browser.
+    WebUrl(String),
+    /// Reveal the location in the system file manager.
+    LocalPath(PathBuf),
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Path Normalization
 // ─────────────────────────────────────────────────────────────────────────────
@@ -162,6 +171,165 @@ pub fn canonicalize_or_normalize(path: &Path) -> PathBuf {
     }
 }
 
+/// True when the target is an HTTP(S) URL.
+pub fn is_http_url(target: &str) -> bool {
+    let target = target.trim();
+    target.starts_with("http://") || target.starts_with("https://")
+}
+
+/// Return the path that should be opened in the system file manager.
+///
+/// Directories open directly. Files reveal their parent directory.
+pub fn explorer_target(path: &Path) -> PathBuf {
+    if path.is_dir() {
+        path.to_path_buf()
+    } else {
+        path.parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    }
+}
+
+/// Open a path in the system file manager.
+pub fn open_in_file_manager(path: &Path) -> std::io::Result<()> {
+    open::that(explorer_target(path))
+}
+
+/// Resolve an openable markdown link target.
+pub fn resolve_openable_link_target(
+    target: &str,
+    current_dir: Option<&Path>,
+    workspace_root: Option<&Path>,
+) -> Option<OpenableLinkTarget> {
+    let target = target.trim();
+    if target.is_empty() {
+        return None;
+    }
+
+    if is_http_url(target) {
+        return Some(OpenableLinkTarget::WebUrl(target.to_string()));
+    }
+
+    resolve_local_link_path(target, current_dir, workspace_root).map(OpenableLinkTarget::LocalPath)
+}
+
+/// Resolve a local markdown link target to an existing file or directory.
+pub fn resolve_local_link_path(
+    target: &str,
+    current_dir: Option<&Path>,
+    workspace_root: Option<&Path>,
+) -> Option<PathBuf> {
+    let target = target.trim();
+    if target.is_empty() || has_non_local_scheme(target) {
+        return None;
+    }
+
+    if let Some(path) = parse_absolute_or_file_url_path(target) {
+        if path.exists() {
+            return Some(canonicalize_or_normalize(&path));
+        }
+    }
+
+    let relative = Path::new(target);
+    if let Some(dir) = current_dir {
+        let candidate = dir.join(relative);
+        if candidate.exists() {
+            return Some(canonicalize_or_normalize(&candidate));
+        }
+    }
+
+    if let Some(root) = workspace_root {
+        let candidate = root.join(relative);
+        if candidate.exists() {
+            return Some(canonicalize_or_normalize(&candidate));
+        }
+    }
+
+    None
+}
+
+fn has_non_local_scheme(target: &str) -> bool {
+    let target = target.trim();
+    target.starts_with("data:")
+        || target.starts_with("mailto:")
+        || target.starts_with("tel:")
+        || target.starts_with("ftp://")
+        || target.starts_with("ws://")
+        || target.starts_with("wss://")
+}
+
+fn parse_absolute_or_file_url_path(target: &str) -> Option<PathBuf> {
+    if let Some(path) = parse_file_url_path(target) {
+        return Some(normalize_local_link_candidate(path));
+    }
+
+    #[cfg(windows)]
+    if let Some(path) = wsl_mount_to_windows_path(target) {
+        return Some(path);
+    }
+
+    if looks_like_windows_absolute_path(target) || target.starts_with(r"\\") {
+        return Some(normalize_path(PathBuf::from(target)));
+    }
+
+    let path = Path::new(target);
+    if path.is_absolute() {
+        return Some(normalize_local_link_candidate(path.to_path_buf()));
+    }
+
+    None
+}
+
+fn parse_file_url_path(target: &str) -> Option<PathBuf> {
+    let parsed = url::Url::parse(target).ok()?;
+    if parsed.scheme() != "file" {
+        return None;
+    }
+    parsed.to_file_path().ok()
+}
+
+fn looks_like_windows_absolute_path(target: &str) -> bool {
+    let bytes = target.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
+fn normalize_local_link_candidate(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let path_str = path.to_string_lossy();
+        if let Some(converted) = wsl_mount_to_windows_path(&path_str) {
+            return converted;
+        }
+    }
+
+    normalize_path(path)
+}
+
+#[cfg(windows)]
+fn wsl_mount_to_windows_path(path: &str) -> Option<PathBuf> {
+    let normalized = path.replace('\\', "/");
+    let rest = normalized.strip_prefix("/mnt/")?;
+    let (drive, suffix) = rest
+        .split_once('/')
+        .map(|(drive, suffix)| (drive, Some(suffix)))
+        .unwrap_or((rest, None));
+    let drive_char = drive.chars().next()?;
+    if drive.len() != 1 || !drive_char.is_ascii_alphabetic() {
+        return None;
+    }
+
+    let mut converted = PathBuf::from(format!("{}:\\", drive_char.to_ascii_uppercase()));
+    if let Some(suffix) = suffix {
+        if !suffix.is_empty() {
+            converted.push(suffix.replace('/', "\\"));
+        }
+    }
+    Some(normalize_path(converted))
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
@@ -250,5 +418,75 @@ mod tests {
         let path = PathBuf::from("/some/path");
         let normalized = normalize_path_ref(&path);
         assert_eq!(normalized, path);
+    }
+
+    #[test]
+    fn test_http_url_detection() {
+        assert!(is_http_url("https://example.com"));
+        assert!(is_http_url("http://example.com"));
+        assert!(!is_http_url("file:///tmp/test.md"));
+    }
+
+    #[test]
+    fn test_openable_link_target_web_url() {
+        let resolved = resolve_openable_link_target("https://example.com", None, None);
+        assert_eq!(
+            resolved,
+            Some(OpenableLinkTarget::WebUrl(
+                "https://example.com".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_explorer_target_reveals_parent_for_files() {
+        let temp_dir = std::env::temp_dir().join("ferrite_explorer_target_test");
+        let _ = std::fs::create_dir_all(&temp_dir);
+        let file = temp_dir.join("note.md");
+        std::fs::write(&file, "# test").unwrap();
+
+        assert_eq!(explorer_target(&file), temp_dir);
+        assert_eq!(explorer_target(&temp_dir), temp_dir);
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_resolve_local_link_path_relative_file() {
+        let temp_dir = std::env::temp_dir().join("ferrite_local_link_relative_file");
+        let _ = std::fs::create_dir_all(&temp_dir);
+        let file = temp_dir.join("target.md");
+        std::fs::write(&file, "# target").unwrap();
+
+        let resolved = resolve_local_link_path("target.md", Some(&temp_dir), None);
+        assert_eq!(resolved, Some(canonicalize_or_normalize(&file)));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_resolve_local_link_path_relative_directory() {
+        let temp_dir = std::env::temp_dir().join("ferrite_local_link_relative_dir");
+        let nested = temp_dir.join("assets");
+        let _ = std::fs::create_dir_all(&nested);
+
+        let resolved = resolve_local_link_path("assets", Some(&temp_dir), None);
+        assert_eq!(resolved, Some(canonicalize_or_normalize(&nested)));
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_parse_windows_absolute_path() {
+        let resolved = parse_absolute_or_file_url_path(r"E:\Zero_Base\sumi_os\WSL");
+        assert_eq!(resolved, Some(PathBuf::from(r"E:\Zero_Base\sumi_os\WSL")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_convert_wsl_mount_path_to_windows_path() {
+        let resolved = parse_absolute_or_file_url_path("/mnt/e/Zero_Base/sumi_os/WSL");
+        assert_eq!(resolved, Some(PathBuf::from(r"E:\Zero_Base\sumi_os\WSL")));
     }
 }


### PR DESCRIPTION
This adds first-class local-path handling for rendered markdown links without mixing it into the CI baseline work.

## What changed
- add a shared local-link resolver in `src/path_utils.rs`
- support these local target forms:
  - Windows absolute paths like `E:\Zero_Base\sumi_os\WSL`
  - `file://` URLs
  - WSL mount paths like `/mnt/e/Zero_Base/sumi_os/WSL`
  - relative local targets using current-file and workspace context
- open resolved local targets in the system file manager instead of treating them as browser-only links
- route image local-path resolution through the same resolver
- reuse the same file-manager reveal helper for existing explorer actions

## Why
Rendered markdown links currently only open `http` / `https` targets. That makes local path links inert even when they point at valid Windows or WSL-backed filesystem locations.

## Validation
- `git diff --check`
- `cargo test --locked -j 1 path_utils::tests -- --nocapture`

## Notes
- Local file targets currently reveal the containing folder in the file manager.
- This PR does not change wikilink navigation semantics.
- This PR does not touch the runtime baseline or packaging baseline follow-up work.
