### PR TITLE
feat: improve rendered markdown interactions

### DIFF
--- a/src/app/central_panel.rs
+++ b/src/app/central_panel.rs
@@ -3020,6 +3020,8 @@ impl FerriteApp {
             }
         }
 
+        crate::ui::MermaidPopupState::render_overlay(&ctx);
+
         // Return deferred format action to be handled after editor has captured selection
         deferred_format_action
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -45,10 +45,10 @@ use crate::preview::SyncScrollState;
 use crate::state::{AppState, FileType, OpenResult, Selection};
 use crate::theme::{ThemeColors, ThemeManager};
 use crate::ui::{
-    consume_clicks_in_resize_zones, handle_window_resize, load_app_logo_texture, AboutPanel,
-    BacklinksPanel, CommandPalette, FileOperationDialog, FileTreeContextAction, FileTreePanel,
-    FrontmatterPanel, OutlinePanel, ProductivityPanel, QuickSwitcher, Ribbon, RibbonAction,
-    RuntimeModulesInfo,
+    consume_clicks_in_resize_zones, handle_window_resize, load_app_logo_texture,
+    markdown_cheatsheet_trigger_rect, render_markdown_cheatsheet, AboutPanel, BacklinksPanel,
+    CommandPalette, FileOperationDialog, FileTreeContextAction, FileTreePanel, FrontmatterPanel,
+    OutlinePanel, ProductivityPanel, QuickSwitcher, Ribbon, RibbonAction, RuntimeModulesInfo,
     SearchPanel, SettingsPanel, TerminalPanel, TerminalPanelState, WelcomePanel, WindowResizeState,
 };
 use crate::vcs::GitAutoRefresh;
@@ -202,6 +202,10 @@ pub struct FerriteApp {
     pending_cjk_check: bool,
     /// Last active tab index (for detecting tab switches to refresh backlinks)
     last_active_tab_for_backlinks: usize,
+    /// Active tab id seen on the previous frame for tab-back history.
+    last_observed_active_tab_id: Option<usize>,
+    /// Previous active tab id, used by the top toolbar back button.
+    previous_active_tab_id: Option<usize>,
     /// Flag to trigger backlink refresh (set on file save or tab switch)
     backlinks_need_refresh: bool,
     /// Single-instance listener for receiving file paths from secondary instances
@@ -530,6 +534,8 @@ impl FerriteApp {
             platform_init_done: false,
             pending_cjk_check: false,
             last_active_tab_for_backlinks: usize::MAX,
+            last_observed_active_tab_id: None,
+            previous_active_tab_id: None,
             backlinks_need_refresh: true,
             instance_listener: None,
             #[cfg(feature = "async-workers")]
@@ -2332,6 +2338,29 @@ impl FerriteApp {
             deferred_format_action = central_deferred;
         }
 
+        if !zen_mode
+            && self
+                .state
+                .active_tab()
+                .map(|tab| tab.file_type().is_markdown())
+                .unwrap_or(false)
+        {
+            let cheatsheet_output = render_markdown_cheatsheet(
+                ui,
+                ui.ctx().content_rect(),
+                is_dark,
+                markdown_cheatsheet_trigger_rect(ui.ctx()),
+                self.state.ui.markdown_cheatsheet_open,
+            );
+            self.state.ui.markdown_cheatsheet_open = cheatsheet_output.expanded;
+            if let Some(command) = cheatsheet_output.open_keyboard_shortcut {
+                self.state.ui.markdown_cheatsheet_open = false;
+                self.open_keyboard_shortcut_settings(command);
+            }
+        } else {
+            self.state.ui.markdown_cheatsheet_open = false;
+        }
+
         self.handle_dropped_files(&ctx, self.viewport_file_open_window());
 
         deferred_format_action
@@ -2409,6 +2438,27 @@ impl FerriteApp {
             }
 
             // View operations
+            RibbonAction::PreviousTab => {
+                debug!("Ribbon: Back to previous tab");
+                if let Some(previous_tab_id) = self.previous_active_tab_id {
+                    let previous_index = (0..self.state.tab_count()).find(|&index| {
+                        self.state
+                            .tab(index)
+                            .is_some_and(|tab| tab.id == previous_tab_id)
+                    });
+                    if let Some(previous_index) = previous_index {
+                        let current_tab_id = self.state.active_tab().map(|tab| tab.id);
+                        if self.state.set_active_tab(previous_index) {
+                            self.previous_active_tab_id = current_tab_id;
+                            self.last_observed_active_tab_id = Some(previous_tab_id);
+                            self.pending_cjk_check = true;
+                            ctx.request_repaint();
+                        }
+                    } else {
+                        self.previous_active_tab_id = None;
+                    }
+                }
+            }
             RibbonAction::ToggleViewMode => {
                 debug!("Ribbon: Toggle view mode");
                 self.handle_toggle_view_mode(ctx);
@@ -2544,6 +2594,11 @@ impl FerriteApp {
                 }
                 self.state.mark_settings_dirty();
             }
+            RibbonAction::ToggleMarkdownCheatsheet => {
+                debug!("Ribbon: Toggle Markdown quick reference");
+                self.state.ui.markdown_cheatsheet_open = !self.state.ui.markdown_cheatsheet_open;
+                ctx.request_repaint();
+            }
             RibbonAction::ToggleFrontmatter => {
                 debug!("Ribbon: Toggle Frontmatter tab in outline panel");
                 if !self.state.settings.outline_enabled {
@@ -2555,11 +2610,32 @@ impl FerriteApp {
             }
         }
     }
+
+    fn track_tab_activation(&mut self) {
+        let current_tab_id = self.state.active_tab().map(|tab| tab.id);
+
+        if current_tab_id != self.last_observed_active_tab_id {
+            if let Some(last_tab_id) = self.last_observed_active_tab_id {
+                if Some(last_tab_id) != current_tab_id {
+                    self.previous_active_tab_id = Some(last_tab_id);
+                }
+            }
+            self.last_observed_active_tab_id = current_tab_id;
+        }
+
+        if let Some(previous_tab_id) = self.previous_active_tab_id {
+            let previous_is_stale = self.state.tab_by_id(previous_tab_id).is_none();
+            if previous_is_stale || Some(previous_tab_id) == current_tab_id {
+                self.previous_active_tab_id = None;
+            }
+        }
+    }
 }
 
 impl eframe::App for FerriteApp {
     fn ui(&mut self, ui: &mut egui::Ui, frame: &mut eframe::Frame) {
         let ctx = ui.ctx().clone();
+        self.track_tab_activation();
         self.state.working_window_id = crate::state::PRIMARY_WINDOW_ID;
         let is_focused = ctx.input(|i| i.viewport().focused.unwrap_or(false));
         if self.viewport_was_focused && !is_focused {
@@ -2667,6 +2743,8 @@ impl eframe::App for FerriteApp {
             let tab_index = self.state.active_tab_index();
             self.try_expand_snippet(tab_index);
         }
+
+        self.track_tab_activation();
     }
 
     /// Called each time the UI needs repainting.

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -6,9 +6,9 @@
 
 use super::types::HeadingNavRequest;
 use super::FerriteApp;
-use crate::config::{Theme, ViewMode};
+use crate::config::{ShortcutCommand, Theme, ViewMode};
 use crate::editor::{extract_outline_for_file, DocumentOutline, DocumentStats, OutlineType};
-use crate::state::{BacklinkIndex, FileType};
+use crate::state::{BacklinkIndex, FileType, SpecialTabKind, TabKind};
 use eframe::egui;
 use log::{debug, info};
 
@@ -389,6 +389,18 @@ impl FerriteApp {
             "Outline panel toggled: {}",
             self.state.settings.outline_enabled
         );
+    }
+
+    /// Open Settings -> Keyboard and prefilter to a specific shortcut command.
+    pub(crate) fn open_keyboard_shortcut_settings(&mut self, command: ShortcutCommand) {
+        let settings_open = self
+            .state
+            .active_tab()
+            .is_some_and(|tab| matches!(&tab.kind, TabKind::Special(SpecialTabKind::Settings)));
+        if !settings_open {
+            self.state.open_settings_tab();
+        }
+        self.settings_panel.open_keyboard_section_for(command);
     }
 
     /// Toggle the terminal panel visibility.

--- a/src/markdown/editor.rs
+++ b/src/markdown/editor.rs
@@ -69,7 +69,10 @@ use crate::markdown::widgets::{
     RenderedLinkState, RenderedLinkWidget, TableData, TableEditState, WidgetColors,
 };
 use crate::path_utils::resolve_local_link_path;
-use crate::ui::{render_nav_buttons, NavAction};
+use crate::ui::{
+    parse_frontmatter_fields, render_nav_buttons, FrontmatterField, FrontmatterValue,
+    MermaidPopupState, NavAction,
+};
 use eframe::egui::{
     self, Color32, ColorImage, FontId, Key, Margin, Response, RichText, ScrollArea, Stroke,
     TextEdit, TextureHandle, TextureOptions, Ui, Vec2,
@@ -1108,20 +1111,26 @@ impl<'a> MarkdownEditor<'a> {
             });
         }
 
-        // Ctrl+Scroll Zoom: detect before ScrollArea consumes the scroll events
-        let ctrl_scroll_zoom: Option<bool> = ui.input(|i| {
-            if !i.modifiers.command {
-                return None;
-            }
-            for event in &i.events {
-                if let egui::Event::MouseWheel { delta, .. } = event {
-                    if delta.y.abs() > 0.01 {
-                        return Some(delta.y > 0.0);
+        // Ctrl+Scroll Zoom: detect before ScrollArea consumes the scroll events.
+        // While a Mermaid popup is open, the popup owns wheel input locally.
+        let popup_open = MermaidPopupState::is_open(ui.ctx());
+        let ctrl_scroll_zoom: Option<bool> = if popup_open {
+            None
+        } else {
+            ui.input(|i| {
+                if !i.modifiers.command {
+                    return None;
+                }
+                for event in &i.events {
+                    if let egui::Event::MouseWheel { delta, .. } = event {
+                        if delta.y.abs() > 0.01 {
+                            return Some(delta.y > 0.0);
+                        }
                     }
                 }
-            }
-            None
-        });
+                None
+            })
+        };
 
         if let Some(is_zoom_in) = ctrl_scroll_zoom {
             if is_zoom_in {
@@ -1239,9 +1248,9 @@ impl<'a> MarkdownEditor<'a> {
         // Collect line mappings during render for scroll sync
         let mut line_mappings: Vec<LineMapping> = Vec::new();
 
-        // Calculate content width and centering margin
-        // Both Zen mode and non-zen mode use max_line_width setting
-        // Zen mode: centers content; Non-zen mode: left-aligned
+        // Calculate content width and centering margin. A configured max line
+        // width should behave as a responsive reading column in rendered view,
+        // not as a left-pinned block outside Zen mode.
         let char_width = self.font_size * 0.6; // Approximate average character width
         let outer_available_width = ui.available_width();
 
@@ -1251,18 +1260,12 @@ impl<'a> MarkdownEditor<'a> {
                 // Cap to available width to prevent overflow
                 let effective_width = max_width_px.min(outer_available_width);
 
-                if self.zen_mode {
-                    // Zen mode: center the content
-                    let margin = if outer_available_width > effective_width {
-                        (outer_available_width - effective_width) / 2.0
-                    } else {
-                        0.0
-                    };
-                    (margin, Some(effective_width))
+                let margin = if outer_available_width > effective_width {
+                    (outer_available_width - effective_width) / 2.0
                 } else {
-                    // Non-zen mode: left-aligned (no margin)
-                    (0.0, Some(effective_width))
-                }
+                    0.0
+                };
+                (margin, Some(effective_width))
             } else {
                 // No max_line_width set - use full available width, no centering
                 (0.0, None)
@@ -5063,6 +5066,17 @@ fn render_mermaid_block(
             .insert_temp(mermaid_block_id.with("state"), mermaid_data);
     });
 
+    if let Some(anchor) = output.open_anchor {
+        MermaidPopupState::request_open(
+            ui.ctx(),
+            output.source,
+            anchor,
+            dark_mode,
+            font_size,
+            mermaid_block_id.value(),
+        );
+    }
+
     // Log if changes were detected (for debugging)
     if output.changed {
         debug!(
@@ -6194,8 +6208,225 @@ fn update_table_in_source(
     }
 }
 
-/// Render front matter (YAML/TOML header).
+/// Render front matter as a read-only document properties panel.
 fn render_front_matter(ui: &mut Ui, colors: &EditorColors, font_size: f32, content: &str) {
+    const BASE_INDENT: f32 = 4.0;
+
+    let normalized_content = normalize_front_matter_content(content);
+    let fields = parse_frontmatter_fields(normalized_content);
+    if fields.is_empty() && !normalized_content.trim().is_empty() {
+        render_front_matter_fallback(ui, colors, font_size, normalized_content);
+        return;
+    }
+
+    let available_width = ui.available_width();
+    let card_width = (available_width - BASE_INDENT - 8.0).max(180.0);
+    let is_dark = ui.visuals().dark_mode;
+    let card_fill = if is_dark {
+        Color32::from_rgba_unmultiplied(28, 31, 38, 138)
+    } else {
+        Color32::from_rgba_unmultiplied(248, 250, 253, 180)
+    };
+    let card_stroke = if is_dark {
+        Color32::from_rgba_unmultiplied(105, 114, 132, 94)
+    } else {
+        Color32::from_rgba_unmultiplied(190, 200, 216, 125)
+    };
+
+    ui.horizontal(|ui| {
+        ui.set_max_width(available_width);
+        ui.add_space(BASE_INDENT);
+
+        ui.vertical(|ui| {
+            ui.set_width(card_width);
+            egui::Frame::new()
+                .fill(card_fill)
+                .stroke(egui::Stroke::new(1.0, card_stroke))
+                .inner_margin(egui::Margin::symmetric(16, 12))
+                .corner_radius(10)
+                .show(ui, |ui| {
+                    let inner_width = (card_width - 32.0).max(140.0);
+                    ui.set_width(inner_width);
+                    ui.horizontal(|ui| {
+                        ui.set_width(inner_width);
+                        ui.label(
+                            RichText::new("Note Properties")
+                                .color(colors.text)
+                                .size(font_size * 0.96)
+                                .strong(),
+                        );
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            let count_text = if fields.len() == 1 {
+                                "1 field".to_string()
+                            } else {
+                                format!("{} fields", fields.len())
+                            };
+                            ui.label(
+                                RichText::new(count_text)
+                                    .color(colors.quote_text)
+                                    .size(font_size * 0.78),
+                            );
+                        });
+                    });
+                    ui.add_space(8.0);
+                    ui.separator();
+                    ui.add_space(8.0);
+
+                    if fields.is_empty() {
+                        ui.label(
+                            RichText::new("No properties")
+                                .color(colors.quote_text)
+                                .size(font_size * 0.9)
+                                .italics(),
+                        );
+                    } else {
+                        ui.spacing_mut().item_spacing.y = 7.0;
+                        for field in &fields {
+                            render_front_matter_property_row(
+                                ui,
+                                colors,
+                                font_size,
+                                field,
+                                inner_width,
+                            );
+                        }
+                    }
+                });
+        });
+    });
+
+    ui.add_space(PARAGRAPH_TRAILING_SPACE_Y);
+}
+
+fn render_front_matter_property_row(
+    ui: &mut Ui,
+    colors: &EditorColors,
+    font_size: f32,
+    field: &FrontmatterField,
+    row_width: f32,
+) {
+    let key_width = (row_width * 0.32).clamp(72.0, 150.0);
+    let value_width = (row_width - key_width - 14.0).max(72.0);
+
+    ui.horizontal(|ui| {
+        ui.set_width(row_width);
+        ui.add_sized(
+            Vec2::new(key_width, 22.0),
+            egui::Label::new(
+                RichText::new(&field.key)
+                    .color(colors.quote_text)
+                    .size(font_size * 0.88),
+            ),
+        );
+
+        ui.vertical(|ui| {
+            ui.set_width(value_width);
+            ui.horizontal_wrapped(|ui| {
+                ui.set_max_width(value_width);
+                ui.spacing_mut().item_spacing = Vec2::new(6.0, 4.0);
+                render_front_matter_property_value(ui, colors, font_size, &field.value);
+            });
+        });
+    });
+}
+
+fn render_front_matter_property_value(
+    ui: &mut Ui,
+    colors: &EditorColors,
+    font_size: f32,
+    value: &FrontmatterValue,
+) {
+    match value {
+        FrontmatterValue::String(value) | FrontmatterValue::Number(value) => {
+            render_front_matter_text_value(ui, colors, font_size, value);
+        }
+        FrontmatterValue::Bool(value) => {
+            let text = if *value { "true" } else { "false" };
+            render_front_matter_pill(ui, colors, font_size, text);
+        }
+        FrontmatterValue::List(items) => {
+            if items.is_empty() {
+                render_front_matter_empty_value(ui, colors, font_size);
+            } else {
+                for item in items {
+                    render_front_matter_pill(ui, colors, font_size, item);
+                }
+            }
+        }
+        FrontmatterValue::Mapping(raw) => {
+            render_front_matter_text_value(ui, colors, font_size, raw);
+        }
+        FrontmatterValue::Null => {
+            render_front_matter_empty_value(ui, colors, font_size);
+        }
+    }
+}
+
+fn render_front_matter_text_value(ui: &mut Ui, colors: &EditorColors, font_size: f32, value: &str) {
+    if value.trim().is_empty() {
+        render_front_matter_empty_value(ui, colors, font_size);
+    } else {
+        ui.add(egui::Label::new(
+            RichText::new(value)
+                .color(colors.text)
+                .size(font_size * 0.96),
+        ));
+    }
+}
+
+fn render_front_matter_empty_value(ui: &mut Ui, colors: &EditorColors, font_size: f32) {
+    ui.label(
+        RichText::new("No value")
+            .color(colors.quote_text)
+            .size(font_size * 0.9)
+            .italics(),
+    );
+}
+
+fn render_front_matter_pill(ui: &mut Ui, colors: &EditorColors, font_size: f32, text: &str) {
+    let is_dark = ui.visuals().dark_mode;
+    let fill = if is_dark {
+        Color32::from_rgba_unmultiplied(95, 105, 125, 150)
+    } else {
+        Color32::from_rgba_unmultiplied(220, 230, 245, 210)
+    };
+    let stroke = if is_dark {
+        Color32::from_rgba_unmultiplied(130, 145, 170, 120)
+    } else {
+        Color32::from_rgba_unmultiplied(175, 190, 220, 170)
+    };
+
+    egui::Frame::new()
+        .fill(fill)
+        .stroke(egui::Stroke::new(1.0, stroke))
+        .corner_radius(egui::CornerRadius::same(10))
+        .inner_margin(egui::Margin::symmetric(8, 2))
+        .show(ui, |ui| {
+            ui.label(
+                RichText::new(text)
+                    .color(colors.text)
+                    .size(font_size * 0.88),
+            );
+        });
+}
+
+fn normalize_front_matter_content(content: &str) -> &str {
+    let trimmed = content.trim();
+    let Some(after_open) = trimmed.strip_prefix("---") else {
+        return content;
+    };
+
+    let after_open = after_open.trim_start_matches(['\r', '\n']);
+    if let Some((yaml, _rest)) = after_open.split_once("\n---") {
+        yaml.trim()
+    } else if let Some((yaml, _rest)) = after_open.split_once("\r\n---") {
+        yaml.trim()
+    } else {
+        content
+    }
+}
+
+fn render_front_matter_fallback(ui: &mut Ui, colors: &EditorColors, font_size: f32, content: &str) {
     const BASE_INDENT: f32 = 4.0;
 
     let available_width = ui.available_width();

--- a/src/markdown/widgets.rs
+++ b/src/markdown/widgets.rs
@@ -23,17 +23,15 @@ use crate::markdown::code_execution::{
 use crate::markdown::parser::{
     CalloutType, HeadingLevel, ListType, MarkdownNode, MarkdownNodeType, TableAlignment,
 };
-use crate::path_utils::{
-    open_in_file_manager, resolve_openable_link_target, OpenableLinkTarget,
-};
+use crate::path_utils::{open_in_file_manager, resolve_openable_link_target, OpenableLinkTarget};
 use crate::terminal::TerminalTheme;
 use crate::ui::phosphor_icons::{
-    phosphor_rich_text, ARROWS_CLOCKWISE, ARROWS_LEFT_RIGHT, BUILDINGS, CALENDAR, CARET_DOWN,
-    CARET_RIGHT, CHART_BAR, CHART_LINE_UP, CHART_PIE, CHECK, DIAMOND, FLOW_ARROW, GIT_BRANCH,
-    HOURGLASS, LINK, LIST_CHECKS, PACKAGE, PLAY, SQUARES_FOUR, STOP, TEXT_ALIGN_CENTER,
+    phosphor_rich_text, ARROWS_CLOCKWISE, ARROWS_LEFT_RIGHT, ARROWS_OUT, BUILDINGS, CALENDAR,
+    CARET_DOWN, CARET_RIGHT, CHART_BAR, CHART_LINE_UP, CHART_PIE, CHECK, DIAMOND, FLOW_ARROW,
+    GIT_BRANCH, HOURGLASS, LINK, LIST_CHECKS, PACKAGE, PLAY, SQUARES_FOUR, STOP, TEXT_ALIGN_CENTER,
     TEXT_ALIGN_LEFT, TEXT_ALIGN_RIGHT, TREE_STRUCTURE, USER, WARNING, X,
 };
-use eframe::egui::{self, Color32, FontFamily, FontId, Key, RichText, TextEdit, Ui};
+use eframe::egui::{self, Color32, FontFamily, FontId, Key, RichText, Sense, TextEdit, Ui};
 use rust_i18n::t;
 use std::time::Duration;
 
@@ -872,9 +870,7 @@ pub fn serialize_node(node: &MarkdownNode) -> String {
                 .map(serialize_node)
                 .collect::<Vec<_>>()
                 .join("\n\n");
-            format!(
-                "<details{open_attr}>\n<summary>{summary}</summary>\n\n{inner}\n\n</details>"
-            )
+            format!("<details{open_attr}>\n<summary>{summary}</summary>\n\n{inner}\n\n</details>")
         }
 
         MarkdownNodeType::VideoEmbed(info) => info.source_text.clone(),
@@ -1110,8 +1106,7 @@ fn table_cell_galley_paint_pos(
     galley: &egui::Galley,
     alignment: TableAlignment,
 ) -> egui::Pos2 {
-    let block_shift =
-        table_cell_block_align_shift(cell_rect.width(), galley.size().x, alignment);
+    let block_shift = table_cell_block_align_shift(cell_rect.width(), galley.size().x, alignment);
     cell_rect.min - galley.rect.min.to_vec2() + egui::vec2(block_shift, 0.0)
 }
 
@@ -1785,9 +1780,7 @@ pub fn signal_table_force_commit(ctx: &egui::Context, table_line: usize) {
 /// Consume the force-commit signal for `table_line` (one-shot).
 fn take_table_force_commit(ui: &mut Ui, table_line: usize) -> bool {
     let id = table_force_commit_id(table_line);
-    let v = ui
-        .memory(|m| m.data.get_temp::<bool>(id))
-        .unwrap_or(false);
+    let v = ui.memory(|m| m.data.get_temp::<bool>(id)).unwrap_or(false);
     if v {
         ui.memory_mut(|m| m.data.remove::<bool>(id));
     }
@@ -2693,9 +2686,7 @@ impl<'a> EditableTable<'a> {
                                                                     ),
                                                                 ),
                                                             );
-                                                            output
-                                                                .state
-                                                                .store(ui.ctx(), cell_id);
+                                                            output.state.store(ui.ctx(), cell_id);
                                                         }
                                                     }
                                                     if response.has_focus() {
@@ -2784,9 +2775,7 @@ impl<'a> EditableTable<'a> {
                                                     if activate_cell && !read_only {
                                                         let cursor_char = ui
                                                             .ctx()
-                                                            .input(|i| {
-                                                                i.pointer.interact_pos()
-                                                            })
+                                                            .input(|i| i.pointer.interact_pos())
                                                             .map(|click_pos| {
                                                                 table_cell_raw_cursor_at_click(
                                                                     ui,
@@ -2875,8 +2864,7 @@ impl<'a> EditableTable<'a> {
                 }
 
                 // Fallback when defocus-only click did not set pending_focus above.
-                let cross_table_edit =
-                    global.active_table.is_some_and(|t| t != table_id);
+                let cross_table_edit = global.active_table.is_some_and(|t| t != table_id);
                 if edit_state.pending_focus.is_none()
                     && !read_only
                     && (edit_state.had_focus_last_frame || cross_table_edit)
@@ -2918,26 +2906,24 @@ impl<'a> EditableTable<'a> {
                                         .get(col)
                                         .copied()
                                         .unwrap_or(TableAlignment::None);
-                                    let cursor_char = self
-                                        .data
-                                        .rows
-                                        .get(row)
-                                        .and_then(|r| r.get(col))
-                                        .map(|cell| {
-                                            table_cell_raw_cursor_at_click(
-                                                ui,
-                                                pos,
-                                                *cell_rect,
-                                                &cell.text,
-                                                self.font_size,
-                                                &ef,
-                                                text_color,
-                                                colors.code_bg,
-                                                inner_w,
-                                                row == 0,
-                                                column_alignment,
-                                            )
-                                        });
+                                    let cursor_char =
+                                        self.data.rows.get(row).and_then(|r| r.get(col)).map(
+                                            |cell| {
+                                                table_cell_raw_cursor_at_click(
+                                                    ui,
+                                                    pos,
+                                                    *cell_rect,
+                                                    &cell.text,
+                                                    self.font_size,
+                                                    &ef,
+                                                    text_color,
+                                                    colors.code_bg,
+                                                    inner_w,
+                                                    row == 0,
+                                                    column_alignment,
+                                                )
+                                            },
+                                        );
                                     request_table_cell_focus(
                                         &mut edit_state,
                                         &mut global,
@@ -3298,12 +3284,11 @@ impl<'a> EditableTable<'a> {
         // it unconditionally would falsely re-activate the cell to the session the
         // frame AFTER the user clicked a heading/paragraph, ping-ponging focus.
         // Gate on actual current focus or in-flight focus intent.
-        let focused_cell_out =
-            if any_cell_has_focus || edit_state.pending_focus.is_some() {
-                edit_state.pending_focus.or(edit_state.focused_cell)
-            } else {
-                None
-            };
+        let focused_cell_out = if any_cell_has_focus || edit_state.pending_focus.is_some() {
+            edit_state.pending_focus.or(edit_state.focused_cell)
+        } else {
+            None
+        };
 
         let pending_focus_dbg = edit_state.pending_focus;
         let pending_cell_dbg = global.pending_cell;
@@ -3806,8 +3791,7 @@ impl<'a> EditableCodeBlock<'a> {
 
         // Per-block run handle keyed by fenced source so line shifts above the
         // block do not orphan in-flight output.
-        let run_state_key =
-            code_exec_mod::code_run_state_key(&self.data.code, &self.data.language);
+        let run_state_key = code_exec_mod::code_run_state_key(&self.data.code, &self.data.language);
         let run_key = run_state_key.with("run_handle");
         let toast_emitted_key = run_state_key.with("run_toast_emitted");
 
@@ -4131,11 +4115,7 @@ impl<'a> EditableCodeBlock<'a> {
             markdown: self.data.to_markdown(),
             code: self.data.code.clone(),
             language: self.data.language.clone(),
-            insert_output_below: if read_only {
-                None
-            } else {
-                insert_output_below
-            },
+            insert_output_below: if read_only { None } else { insert_output_below },
         }
     }
 }
@@ -4879,7 +4859,10 @@ impl<'a> RenderedLinkWidget<'a> {
                                         if let Err(e) = open_link_target(target) {
                                             log::error!("Failed to open link target: {}", e);
                                         } else {
-                                            log::debug!("Opened link target from popup: {:?}", target);
+                                            log::debug!(
+                                                "Opened link target from popup: {:?}",
+                                                target
+                                            );
                                         }
                                     }
                                 }
@@ -5190,6 +5173,10 @@ pub struct MermaidBlockOutput {
     pub markdown: String,
     /// Detected diagram type
     pub diagram_type: MermaidDiagramType,
+    /// Screen position where the popup button or diagram was clicked.
+    pub open_anchor: Option<egui::Pos2>,
+    /// Whether the rendered diagram requested popup open through click gesture.
+    pub open_via_diagram_click: bool,
 }
 
 /// A widget for displaying and editing mermaid diagrams.
@@ -5332,6 +5319,7 @@ impl<'a> MermaidBlock<'a> {
             .corner_radius(egui::CornerRadius::same(6))
             .inner_margin(egui::Margin::same(0));
 
+        let mut open_via_diagram_click = false;
         frame.show(ui, |ui| {
             ui.vertical(|ui| {
                 // Header with diagram type indicator
@@ -5430,12 +5418,103 @@ impl<'a> MermaidBlock<'a> {
                                 // last successfully rendered source.
                                 match validate_mermaid_source(&self.data.source) {
                                     Ok(()) => {
+                                        let diagram_start = ui.cursor().min;
                                         let result = render_mermaid_diagram(
                                             ui,
                                             &self.data.source,
                                             self.dark_mode,
                                             self.font_size,
                                         );
+                                        let diagram_end = ui.min_rect().max;
+                                        let diagram_rect =
+                                            egui::Rect::from_min_max(diagram_start, diagram_end)
+                                                .expand2(egui::vec2(6.0, 6.0));
+                                        let diagram_response = ui.interact(
+                                            diagram_rect,
+                                            block_id.with("diagram_popup_open"),
+                                            Sense::click(),
+                                        );
+                                        if diagram_response.hovered() {
+                                            ui.ctx()
+                                                .set_cursor_icon(egui::CursorIcon::PointingHand);
+                                            diagram_response.clone().on_hover_text(
+                                                "Click diagram or Ctrl+Click to open popup",
+                                            );
+                                        }
+                                        if diagram_response.clicked() {
+                                            ui.memory_mut(|mem| {
+                                                mem.data.insert_temp(
+                                                    block_id.with("popup_anchor"),
+                                                    diagram_response.rect.center(),
+                                                );
+                                            });
+                                            open_via_diagram_click = true;
+                                            ui.ctx().request_repaint();
+                                        }
+                                        let visible_diagram_rect =
+                                            diagram_rect.intersect(ui.clip_rect());
+                                        if visible_diagram_rect.is_positive() {
+                                            let button_size = egui::vec2(30.0, 30.0);
+                                            let button_rect = egui::Rect::from_min_size(
+                                                visible_diagram_rect.right_top()
+                                                    + egui::vec2(-button_size.x - 8.0, 8.0),
+                                                button_size,
+                                            );
+                                            let popup_icon_color = if self.dark_mode {
+                                                egui::Color32::from_rgb(230, 235, 245)
+                                            } else {
+                                                egui::Color32::from_rgb(42, 54, 70)
+                                            };
+                                            let popup_btn = ui
+                                                .put(
+                                                    button_rect,
+                                                    egui::Button::new(
+                                                        phosphor_rich_text(
+                                                            ARROWS_OUT,
+                                                            self.font_size + 3.0,
+                                                        )
+                                                        .color(popup_icon_color),
+                                                    )
+                                                    .fill(if self.dark_mode {
+                                                        egui::Color32::from_rgba_unmultiplied(
+                                                            22, 26, 34, 220,
+                                                        )
+                                                    } else {
+                                                        egui::Color32::from_rgba_unmultiplied(
+                                                            255, 255, 255, 232,
+                                                        )
+                                                    })
+                                                    .stroke(egui::Stroke::new(
+                                                        1.0,
+                                                        if self.dark_mode {
+                                                            egui::Color32::from_rgba_unmultiplied(
+                                                                115, 128, 150, 180,
+                                                            )
+                                                        } else {
+                                                            egui::Color32::from_rgba_unmultiplied(
+                                                                170, 180, 198, 190,
+                                                            )
+                                                        },
+                                                    ))
+                                                    .corner_radius(egui::CornerRadius::same(15))
+                                                    .min_size(button_size),
+                                                )
+                                                .on_hover_text("Open diagram in popup");
+                                            if popup_btn.hovered() {
+                                                ui.ctx()
+                                                    .set_cursor_icon(egui::CursorIcon::PointingHand);
+                                            }
+                                            if popup_btn.clicked() {
+                                                ui.memory_mut(|mem| {
+                                                    mem.data.insert_temp(
+                                                        block_id.with("popup_anchor"),
+                                                        popup_btn.rect.center(),
+                                                    );
+                                                });
+                                                open_via_diagram_click = true;
+                                                ui.ctx().request_repaint();
+                                            }
+                                        }
                                         match result {
                                             RenderResult::Success => {
                                                 self.data.last_good_source =
@@ -5561,6 +5640,16 @@ impl<'a> MermaidBlock<'a> {
             });
         });
 
+        let open_anchor = ui.memory_mut(|mem| {
+            let anchor = mem
+                .data
+                .get_temp::<egui::Pos2>(block_id.with("popup_anchor"));
+            if anchor.is_some() {
+                mem.data.remove::<egui::Pos2>(block_id.with("popup_anchor"));
+            }
+            anchor
+        });
+
         // Check for changes
         let changed = self.data.source != original_source;
 
@@ -5569,6 +5658,8 @@ impl<'a> MermaidBlock<'a> {
             source: self.data.source.clone(),
             markdown: self.data.to_markdown(),
             diagram_type: self.data.diagram_type,
+            open_anchor,
+            open_via_diagram_click,
         }
     }
 }
@@ -6139,7 +6230,11 @@ mod tests {
             .map(str::trim)
             .filter(|cell| !cell.is_empty())
             .collect();
-        assert_eq!(delimiter_cells.len(), 3, "unexpected delimiter row: {separator}");
+        assert_eq!(
+            delimiter_cells.len(),
+            3,
+            "unexpected delimiter row: {separator}"
+        );
         assert!(
             delimiter_cells[0].starts_with(':') && !delimiter_cells[0].ends_with(':'),
             "left column delimiter should start with colon: {}",
@@ -6690,8 +6785,12 @@ mod tests {
             source: "flowchart TD\n  A --> B".to_string(),
             markdown: "```mermaid\nflowchart TD\n  A --> B\n```".to_string(),
             diagram_type: MermaidDiagramType::Flowchart,
+            open_anchor: None,
+            open_via_diagram_click: false,
         };
         assert!(output.changed);
         assert_eq!(output.diagram_type, MermaidDiagramType::Flowchart);
+        assert!(output.open_anchor.is_none());
+        assert!(!output.open_via_diagram_click);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3327,6 +3327,8 @@ pub struct UiState {
     pub rename_untitled_tab: Option<(usize, String)>,
     /// Explicit foreground menu state for the tab-strip context menu: `(tab_index, anchor_pos)`.
     pub tab_context_menu: Option<(usize, egui::Pos2)>,
+    /// Whether the Markdown quick reference panel is currently open.
+    pub markdown_cheatsheet_open: bool,
 }
 
 /// True when a persisted session title matches a special tab (Settings, About, Welcome).

--- a/src/ui/mermaid_popup.rs
+++ b/src/ui/mermaid_popup.rs
@@ -1,0 +1,568 @@
+//! Ferrite-native Mermaid diagram popup overlay with zoom and pan.
+//!
+//! The popup is stored in egui memory so rendered Markdown can open a large
+//! diagram viewer without adding app-level state plumbing.
+
+use egui::{
+    Color32, CornerRadius, DragPanButtons, FontId, Id, Order, Pos2, Rect, Scene, Sense, Stroke,
+    Vec2,
+};
+
+use crate::markdown::mermaid::render_mermaid_diagram;
+use crate::ui::phosphor_icons::{
+    phosphor_rich_text, ARROWS_COUNTER_CLOCKWISE, CURSOR, HAND, MAGNIFYING_GLASS_MINUS,
+    MAGNIFYING_GLASS_PLUS, X,
+};
+
+const POPUP_STATE_KEY: &str = "mermaid_popup_state";
+
+/// Persistent state for the Mermaid diagram popup.
+#[derive(Debug, Clone)]
+pub struct MermaidPopupState {
+    /// Whether the popup is currently visible.
+    pub open: bool,
+    /// The Mermaid source code to render.
+    pub source: String,
+    /// Screen position of the popup's top-left corner.
+    pub position: Pos2,
+    /// Zoom scale factor (1.0 = original size).
+    pub zoom: f32,
+    /// Whether the user is currently dragging the popup.
+    pub dragging: bool,
+    /// Whether dark mode is active.
+    pub dark_mode: bool,
+    /// Base font size for diagram rendering.
+    pub font_size: f32,
+    /// Unique ID to distinguish multiple diagrams.
+    pub diagram_id: u64,
+    /// egui input time when zoom last changed.
+    pub zoom_changed_at: f64,
+    /// Current scene rect for panning/zooming the rendered diagram.
+    pub scene_rect: Rect,
+    /// Current interaction mode for the diagram canvas.
+    pub interaction_mode: MermaidInteractionMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MermaidInteractionMode {
+    Select,
+    Hand,
+}
+
+const POPUP_MARGIN: f32 = 18.0;
+const POPUP_MIN_W: f32 = 640.0;
+const POPUP_MIN_H: f32 = 420.0;
+const DEFAULT_SCENE_SIZE: Vec2 = Vec2::new(1200.0, 900.0);
+const MIN_SCENE_ZOOM: f32 = 0.15;
+const MAX_SCENE_ZOOM: f32 = 5.0;
+const SCENE_ZOOM_STEP: f32 = 0.1;
+
+impl MermaidPopupState {
+    /// Request to open a popup for a diagram.
+    pub fn request_open(
+        ctx: &egui::Context,
+        source: String,
+        _anchor_pos: Pos2,
+        dark_mode: bool,
+        font_size: f32,
+        diagram_id: u64,
+    ) {
+        let screen_rect = ctx.content_rect();
+        let popup_rect = popup_rect_for_screen(screen_rect);
+        let position = popup_rect.min;
+
+        let state = Self {
+            open: true,
+            source,
+            position,
+            zoom: 1.0,
+            dragging: false,
+            dark_mode,
+            font_size,
+            diagram_id,
+            zoom_changed_at: 0.0,
+            scene_rect: Rect::from_min_size(Pos2::ZERO, DEFAULT_SCENE_SIZE),
+            interaction_mode: MermaidInteractionMode::Hand,
+        };
+
+        ctx.memory_mut(|mem| {
+            mem.data.insert_temp(Id::new(POPUP_STATE_KEY), state);
+        });
+    }
+
+    /// Get the current popup state from egui memory.
+    pub fn get(ctx: &egui::Context) -> Option<Self> {
+        ctx.memory(|mem| mem.data.get_temp::<Self>(Id::new(POPUP_STATE_KEY)))
+    }
+
+    /// Returns true while a Mermaid popup is open.
+    pub fn is_open(ctx: &egui::Context) -> bool {
+        Self::get(ctx).is_some_and(|state| state.open)
+    }
+
+    /// Update the popup state in egui memory.
+    pub fn set(&self, ctx: &egui::Context) {
+        ctx.memory_mut(|mem| {
+            mem.data.insert_temp(Id::new(POPUP_STATE_KEY), self.clone());
+        });
+    }
+
+    /// Clear the popup state.
+    pub fn close(ctx: &egui::Context) {
+        ctx.memory_mut(|mem| {
+            mem.data.remove::<Self>(Id::new(POPUP_STATE_KEY));
+        });
+    }
+
+    /// Render the popup overlay if one is open.
+    pub fn render_overlay(ctx: &egui::Context) {
+        let state = Self::get(ctx);
+        let Some(mut state) = state else {
+            return;
+        };
+
+        if !state.open {
+            Self::close(ctx);
+            return;
+        }
+
+        let current_time = ctx.input(|i| i.time);
+        let mut should_close = false;
+
+        {
+            let screen_rect = ctx.content_rect();
+            let painter = ctx.layer_painter(egui::LayerId::new(
+                Order::Background,
+                Id::new("mermaid_popup_bg"),
+            ));
+            painter.rect_filled(screen_rect, 0.0, Color32::from_black_alpha(70));
+        }
+
+        let popup_id = Id::new("mermaid_popup_area").with(state.diagram_id);
+        let screen_rect = ctx.content_rect();
+        let popup_rect = popup_rect_for_screen(screen_rect);
+        state.position = popup_rect.min;
+        let popup_size = popup_rect.size();
+
+        egui::Area::new(popup_id)
+            .order(Order::Foreground)
+            .fixed_pos(state.position)
+            .interactable(true)
+            .sense(Sense::hover())
+            .show(ctx, |ui| {
+                ui.set_min_size(popup_size);
+                ui.set_max_size(popup_size);
+                render_popup_content(ui, &mut state, &mut should_close, current_time);
+            });
+
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            should_close = true;
+            ctx.input_mut(|i| {
+                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            });
+        }
+
+        let popup_rect = Rect::from_min_size(state.position, popup_size);
+        let outside_clicked = ctx.input(|i| {
+            i.pointer.any_click()
+                && i.pointer
+                    .interact_pos()
+                    .is_some_and(|pos| !popup_rect.contains(pos))
+                && !state.dragging
+        });
+        if outside_clicked {
+            should_close = true;
+        }
+
+        if should_close {
+            Self::close(ctx);
+        } else {
+            state.set(ctx);
+        }
+
+        let seconds_since_change = (current_time - state.zoom_changed_at).max(0.0);
+        if seconds_since_change < 1.0 {
+            let alpha = if seconds_since_change > 0.7 {
+                ((1.0 - seconds_since_change) / 0.3 * 200.0) as u8
+            } else {
+                200
+            };
+            let zoom_text = format!("{:.0}%", state.zoom * 100.0);
+            egui::Area::new(Id::new("mermaid_zoom_notification"))
+                .order(Order::Tooltip)
+                .fixed_pos(Pos2::new(
+                    state.position.x + popup_size.x / 2.0 - 30.0,
+                    state.position.y + 42.0,
+                ))
+                .interactable(false)
+                .show(ctx, |ui| {
+                    egui::Frame::new()
+                        .fill(Color32::from_black_alpha(alpha))
+                        .corner_radius(CornerRadius::same(6))
+                        .inner_margin(egui::Margin::symmetric(10, 5))
+                        .show(ui, |ui| {
+                            ui.label(
+                                egui::RichText::new(&zoom_text)
+                                    .font(FontId::proportional(13.0))
+                                    .color(Color32::from_white_alpha(alpha)),
+                            );
+                        });
+                });
+            ctx.request_repaint();
+        }
+    }
+}
+
+fn popup_rect_for_screen(screen_rect: Rect) -> Rect {
+    let margin = Vec2::splat(POPUP_MARGIN);
+    let available = screen_rect.shrink2(margin);
+    let size = Vec2::new(
+        available.width().max(POPUP_MIN_W),
+        available.height().max(POPUP_MIN_H),
+    );
+    Rect::from_min_size(available.min, size)
+}
+
+fn render_popup_content(
+    ui: &mut egui::Ui,
+    state: &mut MermaidPopupState,
+    should_close: &mut bool,
+    current_time: f64,
+) {
+    let icon_color = if state.dark_mode {
+        Color32::from_rgb(180, 180, 190)
+    } else {
+        Color32::from_rgb(80, 80, 90)
+    };
+
+    egui::Frame::new()
+        .fill(Color32::TRANSPARENT)
+        .stroke(Stroke::NONE)
+        .inner_margin(0)
+        .show(ui, |ui| {
+            let title_frame = egui::Frame::new()
+                .fill(if state.dark_mode {
+                    Color32::from_rgba_unmultiplied(28, 28, 34, 225)
+                } else {
+                    Color32::from_rgba_unmultiplied(246, 247, 250, 226)
+                })
+                .stroke(Stroke::new(
+                    1.0,
+                    if state.dark_mode {
+                        Color32::from_rgba_unmultiplied(85, 85, 100, 180)
+                    } else {
+                        Color32::from_rgba_unmultiplied(170, 175, 190, 190)
+                    },
+                ))
+                .inner_margin(egui::Margin::symmetric(12, 6))
+                .corner_radius(CornerRadius::same(10))
+                .shadow(egui::epaint::Shadow {
+                    offset: [0, 3],
+                    blur: 18,
+                    spread: 0,
+                    color: Color32::from_black_alpha(70),
+                });
+
+            title_frame.show(ui, |ui| {
+                state.dragging = false;
+
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new("Mermaid Diagram")
+                            .font(FontId::proportional(13.0))
+                            .strong()
+                            .color(if state.dark_mode {
+                                Color32::from_rgb(200, 200, 210)
+                            } else {
+                                Color32::from_rgb(60, 60, 70)
+                            }),
+                    );
+
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let close_btn = ui.add(
+                            egui::Button::new(phosphor_rich_text(X, 14.0).color(icon_color))
+                                .frame(false)
+                                .small(),
+                        );
+                        if close_btn.clicked() {
+                            *should_close = true;
+                        }
+                        close_btn.on_hover_text("Close popup (Esc)");
+
+                        ui.add_space(4.0);
+
+                        let reset_btn = ui.add(
+                            egui::Button::new(
+                                phosphor_rich_text(ARROWS_COUNTER_CLOCKWISE, 14.0)
+                                    .color(icon_color),
+                            )
+                            .frame(false)
+                            .small(),
+                        );
+                        if reset_btn.clicked() {
+                            set_scene_zoom(&mut state.scene_rect, 1.0, None);
+                            state.zoom = current_scene_zoom(state.scene_rect);
+                            state.zoom_changed_at = current_time;
+                            ui.ctx().request_repaint();
+                        }
+                        reset_btn.on_hover_text("Reset zoom to 100%");
+
+                        ui.add_space(2.0);
+
+                        let zoom_out_btn = ui.add(
+                            egui::Button::new(
+                                phosphor_rich_text(MAGNIFYING_GLASS_MINUS, 14.0).color(icon_color),
+                            )
+                            .frame(false)
+                            .small(),
+                        );
+                        if zoom_out_btn.clicked() {
+                            let new_zoom = (current_scene_zoom(state.scene_rect) - SCENE_ZOOM_STEP)
+                                .clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM);
+                            set_scene_zoom(&mut state.scene_rect, new_zoom, None);
+                            state.zoom = current_scene_zoom(state.scene_rect);
+                            state.zoom_changed_at = current_time;
+                            ui.ctx().request_repaint();
+                        }
+                        zoom_out_btn.on_hover_text("Zoom out");
+
+                        ui.add_space(2.0);
+
+                        let zoom_in_btn = ui.add(
+                            egui::Button::new(
+                                phosphor_rich_text(MAGNIFYING_GLASS_PLUS, 14.0).color(icon_color),
+                            )
+                            .frame(false)
+                            .small(),
+                        );
+                        if zoom_in_btn.clicked() {
+                            let new_zoom = (current_scene_zoom(state.scene_rect) + SCENE_ZOOM_STEP)
+                                .clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM);
+                            set_scene_zoom(&mut state.scene_rect, new_zoom, None);
+                            state.zoom = current_scene_zoom(state.scene_rect);
+                            state.zoom_changed_at = current_time;
+                            ui.ctx().request_repaint();
+                        }
+                        zoom_in_btn.on_hover_text("Zoom in");
+
+                        ui.add_space(6.0);
+
+                        let zoom_text = format!("{:.0}%", state.zoom * 100.0);
+                        ui.label(
+                            egui::RichText::new(&zoom_text)
+                                .font(FontId::monospace(11.0))
+                                .color(if state.dark_mode {
+                                    Color32::from_rgb(150, 150, 165)
+                                } else {
+                                    Color32::from_rgb(90, 90, 100)
+                                }),
+                        );
+
+                        ui.add_space(8.0);
+
+                        if mode_button(
+                            ui,
+                            CURSOR,
+                            icon_color,
+                            state.interaction_mode == MermaidInteractionMode::Select,
+                            "Select mode: drag to move, wheel zoom disabled",
+                        )
+                        .clicked()
+                        {
+                            state.interaction_mode = MermaidInteractionMode::Select;
+                        }
+
+                        if mode_button(
+                            ui,
+                            HAND,
+                            icon_color,
+                            state.interaction_mode == MermaidInteractionMode::Hand,
+                            "Hand mode: drag to move, wheel zooms",
+                        )
+                        .clicked()
+                        {
+                            state.interaction_mode = MermaidInteractionMode::Hand;
+                        }
+                    });
+                });
+            });
+
+            let content_frame = egui::Frame::new()
+                .fill(if state.dark_mode {
+                    Color32::from_rgba_unmultiplied(12, 14, 18, 190)
+                } else {
+                    Color32::from_rgba_unmultiplied(252, 253, 255, 214)
+                })
+                .stroke(Stroke::new(
+                    1.0,
+                    if state.dark_mode {
+                        Color32::from_rgba_unmultiplied(100, 108, 125, 125)
+                    } else {
+                        Color32::from_rgba_unmultiplied(178, 186, 202, 150)
+                    },
+                ))
+                .inner_margin(egui::Margin::symmetric(10, 10))
+                .corner_radius(CornerRadius::same(12))
+                .shadow(egui::epaint::Shadow {
+                    offset: [0, 6],
+                    blur: 28,
+                    spread: 0,
+                    color: Color32::from_black_alpha(75),
+                });
+
+            content_frame.show(ui, |ui| {
+                let content_rect = ui.available_rect_before_wrap();
+                let hover_pos = ui.input(|i| i.pointer.hover_pos());
+                let pointer_over_content = hover_pos.is_some_and(|pos| content_rect.contains(pos));
+                let wheel_delta = if pointer_over_content {
+                    ui.input(|i| i.smooth_scroll_delta.y)
+                } else {
+                    0.0
+                };
+                let zoom_anchor = hover_pos
+                    .filter(|pos| content_rect.contains(*pos))
+                    .map(|pos| viewport_pos_to_scene_pos(content_rect, state.scene_rect, pos));
+
+                if pointer_over_content && wheel_delta.abs() > f32::EPSILON {
+                    ui.input_mut(|i| {
+                        i.smooth_scroll_delta = Vec2::ZERO;
+                        i.events
+                            .retain(|e| !matches!(e, egui::Event::MouseWheel { .. }));
+                    });
+                }
+
+                let scene_zoom_before = current_scene_zoom(state.scene_rect);
+                let scene_scale = scene_fit_scale(content_rect, state.scene_rect);
+                let scene_zoom_range = if state.interaction_mode == MermaidInteractionMode::Select {
+                    scene_scale..=scene_scale
+                } else {
+                    MIN_SCENE_ZOOM..=MAX_SCENE_ZOOM
+                };
+                let scene = Scene::new()
+                    .zoom_range(scene_zoom_range)
+                    .sense(Sense::click_and_drag())
+                    .drag_pan_buttons(DragPanButtons::PRIMARY);
+
+                let scene_response = scene.show(ui, &mut state.scene_rect, |ui| {
+                    render_mermaid_diagram(ui, &state.source, state.dark_mode, state.font_size);
+                });
+
+                if state.interaction_mode == MermaidInteractionMode::Hand
+                    && pointer_over_content
+                    && wheel_delta.abs() > f32::EPSILON
+                {
+                    let current_zoom = current_scene_zoom(state.scene_rect);
+                    let target_zoom = if wheel_delta > 0.0 {
+                        (current_zoom + SCENE_ZOOM_STEP).clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM)
+                    } else {
+                        (current_zoom - SCENE_ZOOM_STEP).clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM)
+                    };
+                    if (target_zoom - current_zoom).abs() > 0.001 {
+                        set_scene_zoom(&mut state.scene_rect, target_zoom, zoom_anchor);
+                        state.zoom = current_scene_zoom(state.scene_rect);
+                        state.zoom_changed_at = current_time;
+                        ui.ctx().request_repaint();
+                    }
+                } else if state.interaction_mode == MermaidInteractionMode::Select
+                    && scene_response.response.changed()
+                {
+                    let derived_zoom = current_scene_zoom(state.scene_rect);
+                    if (derived_zoom - scene_zoom_before).abs() > 0.001 {
+                        set_scene_zoom(&mut state.scene_rect, scene_zoom_before, None);
+                    }
+                    state.zoom = scene_zoom_before;
+                } else if scene_response.response.changed() {
+                    let derived_zoom = current_scene_zoom(state.scene_rect);
+                    if (derived_zoom - state.zoom).abs() > 0.001 {
+                        state.zoom = derived_zoom;
+                        state.zoom_changed_at = current_time;
+                    }
+                }
+
+                if scene_response.response.hovered() || scene_response.response.dragged() {
+                    let cursor_icon = match state.interaction_mode {
+                        MermaidInteractionMode::Select => egui::CursorIcon::Default,
+                        MermaidInteractionMode::Hand => {
+                            if scene_response.response.dragged() {
+                                egui::CursorIcon::Grabbing
+                            } else {
+                                egui::CursorIcon::Grab
+                            }
+                        }
+                    };
+                    ui.ctx().set_cursor_icon(cursor_icon);
+                }
+            });
+        });
+}
+
+fn mode_button(
+    ui: &mut egui::Ui,
+    icon: &str,
+    icon_color: Color32,
+    selected: bool,
+    hover_text: &str,
+) -> egui::Response {
+    ui.add(
+        egui::Button::new(phosphor_rich_text(icon, 14.0).color(icon_color))
+            .selected(selected)
+            .frame(true)
+            .min_size(Vec2::splat(24.0)),
+    )
+    .on_hover_text(hover_text)
+}
+
+fn current_scene_zoom(scene_rect: Rect) -> f32 {
+    (DEFAULT_SCENE_SIZE.x / scene_rect.width().abs().max(f32::EPSILON))
+        .clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM)
+}
+
+fn scene_fit_scale(viewport_rect: Rect, scene_rect: Rect) -> f32 {
+    let scene_size = scene_rect.size();
+    let scale_x = viewport_rect.width() / scene_size.x.abs().max(f32::EPSILON);
+    let scale_y = viewport_rect.height() / scene_size.y.abs().max(f32::EPSILON);
+    scale_x.min(scale_y).clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM)
+}
+
+fn set_scene_zoom(scene_rect: &mut Rect, zoom: f32, anchor_in_scene: Option<Pos2>) {
+    let zoom = zoom.clamp(MIN_SCENE_ZOOM, MAX_SCENE_ZOOM);
+    let old_size = scene_rect.size();
+    let new_size = Vec2::new(DEFAULT_SCENE_SIZE.x / zoom, DEFAULT_SCENE_SIZE.y / zoom);
+
+    let new_rect = if let Some(anchor) = anchor_in_scene {
+        let rel_x = if old_size.x.abs() > f32::EPSILON {
+            (anchor.x - scene_rect.min.x) / old_size.x
+        } else {
+            0.5
+        };
+        let rel_y = if old_size.y.abs() > f32::EPSILON {
+            (anchor.y - scene_rect.min.y) / old_size.y
+        } else {
+            0.5
+        };
+        let min = Pos2::new(anchor.x - rel_x * new_size.x, anchor.y - rel_y * new_size.y);
+        Rect::from_min_size(min, new_size)
+    } else {
+        Rect::from_center_size(scene_rect.center(), new_size)
+    };
+
+    *scene_rect = new_rect;
+}
+
+fn viewport_pos_to_scene_pos(viewport_rect: Rect, scene_rect: Rect, viewport_pos: Pos2) -> Pos2 {
+    let rel_x = if viewport_rect.width().abs() > f32::EPSILON {
+        ((viewport_pos.x - viewport_rect.min.x) / viewport_rect.width()).clamp(0.0, 1.0)
+    } else {
+        0.5
+    };
+    let rel_y = if viewport_rect.height().abs() > f32::EPSILON {
+        ((viewport_pos.y - viewport_rect.min.y) / viewport_rect.height()).clamp(0.0, 1.0)
+    } else {
+        0.5
+    };
+
+    Pos2::new(
+        scene_rect.min.x + scene_rect.width() * rel_x,
+        scene_rect.min.y + scene_rect.height() * rel_y,
+    )
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,6 +13,7 @@ mod file_tree;
 pub mod format_toolbar;
 mod frontmatter_panel;
 mod icons;
+mod mermaid_popup;
 mod nav_buttons;
 mod outline_panel;
 pub mod phosphor_icons;
@@ -38,14 +39,19 @@ pub use dialogs::{FileOperationDialog, FileOperationResult, GoToLineDialog, GoTo
 pub use file_index_progress::file_index_progress_ui;
 pub use file_tree::{FileTreeContextAction, FileTreePanel};
 pub use format_toolbar::{side_panel_toggle_strip, FormatToolbar};
-pub use frontmatter_panel::FrontmatterPanel;
+pub use frontmatter_panel::{
+    parse_frontmatter_fields, FrontmatterField, FrontmatterPanel, FrontmatterValue,
+};
 pub use icons::{get_app_icon, load_app_logo_texture};
-pub use nav_buttons::{render_nav_buttons, set_overlay_blocks_nav_buttons, NavAction};
+pub use mermaid_popup::MermaidPopupState;
+pub use nav_buttons::{
+    render_markdown_cheatsheet, render_nav_buttons, set_overlay_blocks_nav_buttons, NavAction,
+};
 pub use outline_panel::{OutlinePanel, OutlinePanelTab};
 pub use pipeline::{PipelinePanel, TabPipelineState};
 pub use productivity_panel::ProductivityPanel;
 pub use quick_switcher::QuickSwitcher;
-pub use ribbon::{Ribbon, RibbonAction};
+pub use ribbon::{markdown_cheatsheet_trigger_rect, Ribbon, RibbonAction};
 pub use runtime_modules::RuntimeModulesInfo;
 pub use search::{SearchNavigationTarget, SearchPanel};
 pub use settings::SettingsPanel;

--- a/src/ui/nav_buttons.rs
+++ b/src/ui/nav_buttons.rs
@@ -16,8 +16,15 @@
 //! }
 //! ```
 
-use crate::ui::phosphor_icons::{phosphor_font, CARET_DOWN, CARET_UP};
-use eframe::egui::{self, Color32, Context, Pos2, Rect, Sense, StrokeKind, Ui, Vec2};
+use crate::config::ShortcutCommand;
+use crate::ui::phosphor_icons::{
+    phosphor_font, CARET_DOWN, CARET_UP, CODE, CODE_BLOCK, LINK, LIST_BULLETS, TEXT_B, TEXT_ITALIC,
+    X,
+};
+use eframe::egui::{
+    self, Color32, Context, Pos2, Rect, RichText, ScrollArea, Sense, Shadow, Stroke, StrokeKind,
+    Ui, Vec2,
+};
 
 /// Temp data key: when true, nav buttons are hidden (modal overlays are open).
 fn overlay_blocks_nav_id() -> egui::Id {
@@ -194,6 +201,455 @@ pub fn render_nav_buttons(ui: &mut Ui, editor_rect: Rect, is_dark_mode: bool) ->
     });
 
     action
+}
+
+/// Output from the Markdown quick reference overlay.
+#[derive(Debug, Clone, Default)]
+pub struct MarkdownCheatsheetOutput {
+    /// If set, open Settings -> Keyboard and filter to the selected command.
+    pub open_keyboard_shortcut: Option<ShortcutCommand>,
+    /// Current expanded/collapsed visibility after this frame.
+    pub expanded: bool,
+}
+
+/// Render a compact Markdown syntax and shortcut cheat sheet near a toolbar trigger.
+pub fn render_markdown_cheatsheet(
+    ui: &mut Ui,
+    editor_rect: Rect,
+    is_dark_mode: bool,
+    trigger_rect: Option<Rect>,
+    expanded: bool,
+) -> MarkdownCheatsheetOutput {
+    let mut output = MarkdownCheatsheetOutput {
+        expanded,
+        ..Default::default()
+    };
+
+    if ui
+        .ctx()
+        .data(|d| d.get_temp::<bool>(overlay_blocks_nav_id()).unwrap_or(false))
+    {
+        return output;
+    }
+
+    if editor_rect.width() < 180.0 || editor_rect.height() < 120.0 || !output.expanded {
+        return output;
+    }
+
+    let width = editor_rect.width().clamp(240.0, 304.0);
+    let height = (editor_rect.height() - 28.0).clamp(238.0, 330.0);
+    let pos = markdown_cheatsheet_panel_pos(editor_rect, trigger_rect, output.expanded);
+    let panel_rect = Rect::from_min_size(pos, Vec2::new(width, height));
+    let mouse_pos = ui.input(|i| i.pointer.hover_pos());
+    let hovered = mouse_pos.is_some_and(|p| panel_rect.expand(8.0).contains(p));
+
+    let bg = panel_bg(is_dark_mode, hovered || output.expanded);
+    let border = panel_border(is_dark_mode, hovered || output.expanded);
+    let shadow = if hovered || output.expanded {
+        if is_dark_mode {
+            Shadow {
+                offset: [0, 10],
+                blur: 28,
+                spread: 0,
+                color: Color32::from_black_alpha(110),
+            }
+        } else {
+            Shadow {
+                offset: [0, 12],
+                blur: 30,
+                spread: 0,
+                color: Color32::from_black_alpha(30),
+            }
+        }
+    } else {
+        Shadow {
+            offset: [0, 6],
+            blur: 18,
+            spread: 0,
+            color: Color32::from_black_alpha(if is_dark_mode { 70 } else { 18 }),
+        }
+    };
+
+    egui::Area::new(egui::Id::new("markdown_cheatsheet_area"))
+        .order(egui::Order::Foreground)
+        .fixed_pos(pos)
+        .interactable(true)
+        .show(ui.ctx(), |ui| {
+            let (rect, _response) =
+                ui.allocate_exact_size(Vec2::new(width, height), Sense::hover());
+            ui.set_clip_rect(rect.expand(2.0));
+            ui.painter().add(shadow.as_shape(rect, 9));
+            ui.painter().rect_filled(rect, 9.0, bg);
+            ui.painter()
+                .rect_stroke(rect, 9.0, Stroke::new(1.0, border), StrokeKind::Inside);
+
+            let mut content_ui = ui.new_child(
+                egui::UiBuilder::new()
+                    .max_rect(rect.shrink2(Vec2::new(6.0, 3.0)))
+                    .layout(egui::Layout::top_down(egui::Align::LEFT)),
+            );
+            let mut expanded = output.expanded;
+            draw_cheatsheet_expanded(&mut content_ui, is_dark_mode, &mut expanded, &mut output);
+            output.expanded = expanded;
+        });
+
+    let clicked_outside = ui.ctx().input(|i| {
+        i.pointer.any_click()
+            && i.pointer.interact_pos().is_some_and(|pos| {
+                markdown_cheatsheet_should_dismiss_click(panel_rect, trigger_rect, pos)
+            })
+    });
+    let escape_pressed = ui.ctx().input(|i| i.key_pressed(egui::Key::Escape));
+    if clicked_outside || escape_pressed {
+        output.expanded = false;
+    }
+
+    output
+}
+
+fn draw_cheatsheet_expanded(
+    ui: &mut Ui,
+    is_dark: bool,
+    expanded: &mut bool,
+    output: &mut MarkdownCheatsheetOutput,
+) {
+    let text = text_color(is_dark, true);
+    let muted = text_color(is_dark, false);
+    let code_bg = if is_dark {
+        Color32::from_rgba_unmultiplied(255, 255, 255, 18)
+    } else {
+        Color32::from_rgba_unmultiplied(0, 0, 0, 14)
+    };
+
+    ui.spacing_mut().item_spacing = Vec2::new(4.0, 2.0);
+    ui.spacing_mut().button_padding = Vec2::new(4.0, 2.0);
+    ui.horizontal(|ui| {
+        ui.add_space(6.0);
+        ui.label(
+            RichText::new("Markdown guide")
+                .size(13.0)
+                .strong()
+                .color(text),
+        );
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            let close_response = ui
+                .add(
+                    egui::Button::new(RichText::new(X).font(phosphor_font(11.0)).color(muted))
+                        .frame(false)
+                        .min_size(Vec2::new(24.0, 22.0)),
+                )
+                .on_hover_text("Collapse");
+            if close_response.clicked() {
+                *expanded = false;
+            }
+        });
+    });
+
+    let guide_url = "https://www.markdownguide.org/basic-syntax/";
+    ui.hyperlink_to(guide_url, guide_url)
+        .on_hover_text("Open Markdown Guide");
+
+    ui.add_space(3.0);
+    ui.separator();
+    ui.add_space(3.0);
+
+    ui.set_width(ui.available_width());
+    ScrollArea::vertical()
+        .id_salt("markdown_cheatsheet_rows")
+        .auto_shrink([false, false])
+        .max_height(ui.available_height())
+        .show(ui, |ui| {
+            cheat_row(
+                ui,
+                TEXT_B,
+                "Bold",
+                "**text**",
+                "Ctrl+B",
+                Some(ShortcutCommand::FormatBold),
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                TEXT_ITALIC,
+                "Italic",
+                "*text*",
+                "Ctrl+I",
+                Some(ShortcutCommand::FormatItalic),
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                CODE,
+                "Inline code",
+                "`code`",
+                "Ctrl+Shift+`",
+                Some(ShortcutCommand::FormatInlineCode),
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                LINK,
+                "Link",
+                "[text](url)",
+                "Ctrl+K",
+                Some(ShortcutCommand::FormatLink),
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                CODE_BLOCK,
+                "Code block",
+                "```lang",
+                "Ctrl+Shift+C",
+                Some(ShortcutCommand::FormatCodeBlock),
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                "$",
+                "Math",
+                "$$E=mc^2$$",
+                "-",
+                None,
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                "x2",
+                "Superscript",
+                "x^2",
+                "-",
+                None,
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui,
+                ".*",
+                "Regex escape",
+                "\\d+ or \\*",
+                "-",
+                None,
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+            cheat_row(
+                ui, "^", "Footnote", "[^1]", "-", None, text, muted, code_bg, expanded, output,
+            );
+            cheat_row(
+                ui,
+                LIST_BULLETS,
+                "Task list",
+                "- [x] item",
+                "-",
+                None,
+                text,
+                muted,
+                code_bg,
+                expanded,
+                output,
+            );
+        });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cheat_row(
+    ui: &mut Ui,
+    icon: &str,
+    label: &str,
+    syntax: &str,
+    shortcut: &str,
+    shortcut_command: Option<ShortcutCommand>,
+    text: Color32,
+    muted: Color32,
+    code_bg: Color32,
+    expanded: &mut bool,
+    output: &mut MarkdownCheatsheetOutput,
+) {
+    let row_height = 28.0;
+    let rect = ui
+        .allocate_exact_size(Vec2::new(ui.available_width(), row_height), Sense::hover())
+        .0;
+    let response = ui.interact(rect, ui.id().with(label), Sense::hover());
+
+    if response.hovered() {
+        ui.painter().rect_filled(
+            rect.shrink2(Vec2::new(4.0, 2.0)),
+            6.0,
+            code_bg.gamma_multiply(1.6),
+        );
+    }
+
+    let icon_pos = Pos2::new(rect.left() + 13.0, rect.center().y);
+    let icon_font = if icon == "x2" || icon == ".*" || icon == "^" || icon == "$" {
+        egui::FontId::proportional(12.0)
+    } else {
+        phosphor_font(12.0)
+    };
+    ui.painter().text(
+        icon_pos,
+        egui::Align2::CENTER_CENTER,
+        icon,
+        icon_font,
+        muted,
+    );
+
+    ui.painter().text(
+        Pos2::new(rect.left() + 27.0, rect.center().y),
+        egui::Align2::LEFT_CENTER,
+        label,
+        egui::FontId::proportional(12.2),
+        text,
+    );
+
+    let shortcut_rect = Rect::from_min_size(
+        Pos2::new(rect.right() - 82.0, rect.center().y - 9.0),
+        Vec2::new(74.0, 18.0),
+    );
+    let shortcut_response = ui.interact(
+        shortcut_rect,
+        ui.id().with((label, "shortcut")),
+        Sense::click(),
+    );
+    let shortcut_fill = if shortcut_response.hovered() {
+        code_bg.gamma_multiply(1.45)
+    } else {
+        code_bg
+    };
+    ui.painter().rect_filled(shortcut_rect, 5.0, shortcut_fill);
+    ui.painter().text(
+        shortcut_rect.center(),
+        egui::Align2::CENTER_CENTER,
+        shortcut,
+        egui::FontId::monospace(10.5),
+        if shortcut_response.hovered() {
+            text
+        } else {
+            muted
+        },
+    );
+
+    if let Some(command) = shortcut_command {
+        let response = shortcut_response
+            .clone()
+            .on_hover_text("Open Keyboard shortcuts")
+            .on_hover_cursor(egui::CursorIcon::PointingHand);
+        if response.clicked() {
+            output.open_keyboard_shortcut = Some(command);
+            output.expanded = false;
+            *expanded = false;
+        }
+    }
+
+    ui.painter().text(
+        Pos2::new(rect.right() - 92.0, rect.center().y),
+        egui::Align2::RIGHT_CENTER,
+        syntax,
+        egui::FontId::monospace(10.8),
+        muted,
+    );
+}
+
+fn markdown_cheatsheet_should_dismiss_click(
+    panel_rect: Rect,
+    trigger_rect: Option<Rect>,
+    click_pos: Pos2,
+) -> bool {
+    !panel_rect.expand(6.0).contains(click_pos)
+        && !trigger_rect.is_some_and(|rect| rect.expand(6.0).contains(click_pos))
+}
+
+pub(crate) fn markdown_cheatsheet_panel_pos(
+    editor_rect: Rect,
+    trigger_rect: Option<Rect>,
+    expanded: bool,
+) -> Pos2 {
+    let width = if expanded {
+        editor_rect.width().clamp(240.0, 304.0)
+    } else {
+        138.0
+    };
+    let height = if expanded {
+        (editor_rect.height() - 28.0).clamp(238.0, 330.0)
+    } else {
+        30.0
+    };
+    let margin = Vec2::new(12.0, 12.0);
+    if let Some(trigger_rect) = trigger_rect {
+        let x = (trigger_rect.center().x - width / 2.0).clamp(
+            editor_rect.min.x + margin.x,
+            editor_rect.max.x - width - margin.x,
+        );
+        let preferred_below = trigger_rect.max.y + 10.0;
+        let y = if preferred_below + height <= editor_rect.max.y - margin.y {
+            preferred_below
+        } else {
+            (trigger_rect.min.y - height - 10.0).max(editor_rect.min.y + margin.y)
+        };
+        Pos2::new(x, y)
+    } else {
+        Pos2::new(
+            (editor_rect.max.x - width - margin.x).max(editor_rect.min.x + margin.x),
+            (editor_rect.max.y - height - margin.y).max(editor_rect.min.y + margin.y),
+        )
+    }
+}
+
+fn panel_bg(is_dark: bool, active: bool) -> Color32 {
+    match (is_dark, active) {
+        (true, true) => Color32::from_rgba_unmultiplied(35, 37, 44, 238),
+        (true, false) => Color32::from_rgba_unmultiplied(35, 37, 44, 200),
+        (false, true) => Color32::from_rgba_unmultiplied(255, 255, 255, 242),
+        (false, false) => Color32::from_rgba_unmultiplied(255, 255, 255, 210),
+    }
+}
+
+fn panel_border(is_dark: bool, active: bool) -> Color32 {
+    match (is_dark, active) {
+        (true, true) => Color32::from_rgba_unmultiplied(255, 255, 255, 44),
+        (true, false) => Color32::from_rgba_unmultiplied(255, 255, 255, 24),
+        (false, true) => Color32::from_rgba_unmultiplied(0, 0, 0, 38),
+        (false, false) => Color32::from_rgba_unmultiplied(0, 0, 0, 18),
+    }
+}
+
+fn text_color(is_dark: bool, strong: bool) -> Color32 {
+    match (is_dark, strong) {
+        (true, true) => Color32::from_rgb(236, 237, 241),
+        (true, false) => Color32::from_rgb(172, 176, 188),
+        (false, true) => Color32::from_rgb(42, 45, 54),
+        (false, false) => Color32::from_rgb(104, 110, 124),
+    }
 }
 
 /// Returns (background_color, text_color) for a button based on theme and hover state.

--- a/src/ui/ribbon.rs
+++ b/src/ui/ribbon.rs
@@ -13,9 +13,9 @@ use crate::theme::ThemeColors;
 use crate::ui::icons::{phosphor_font, phosphor_rich_text, RIBBON_ICON_SIZE};
 use eframe::egui::{self, Color32, Response, RichText, Ui, Vec2};
 use egui_phosphor::regular::{
-    APP_WINDOW, CHECK, CLIPBOARD, EXPORT, FILE_MAGNIFYING_GLASS, FILE_PDF, FILE_PLUS, FILE_TEXT,
-    FLOPPY_DISK, FOLDERS, FOLDER_SIMPLE_MINUS, GLOBE, LIGHTNING, MAGNIFYING_GLASS, PRINTER,
-    SPARKLE, TERMINAL_WINDOW,
+    APP_WINDOW, ARROW_LEFT, CHECK, CLIPBOARD, EXPORT, FILE_MAGNIFYING_GLASS, FILE_PDF, FILE_PLUS,
+    FILE_TEXT, FLOPPY_DISK, FOLDERS, FOLDER_SIMPLE_MINUS, GLOBE, LIGHTNING, MAGNIFYING_GLASS,
+    PRINTER, SPARKLE, TERMINAL_WINDOW,
 };
 use rust_i18n::t;
 
@@ -24,6 +24,15 @@ const RIBBON_HEIGHT: f32 = 28.0;
 
 /// Size of icon buttons.
 const ICON_BUTTON_SIZE: Vec2 = Vec2::new(32.0, 28.0);
+
+fn markdown_cheatsheet_trigger_rect_id() -> egui::Id {
+    egui::Id::new("ribbon_markdown_cheatsheet_trigger_rect")
+}
+
+/// Last frame rect for the ribbon Markdown quick reference trigger.
+pub fn markdown_cheatsheet_trigger_rect(ctx: &egui::Context) -> Option<egui::Rect> {
+    ctx.data(|d| d.get_temp::<egui::Rect>(markdown_cheatsheet_trigger_rect_id()))
+}
 
 /// Actions that can be triggered from the ribbon.
 ///
@@ -79,6 +88,8 @@ pub enum RibbonAction {
     TogglePipeline,
 
     // View operations (kept for keyboard shortcut handling, but removed from ribbon)
+    /// Switch back to the previously active tab.
+    PreviousTab,
     /// Toggle between Raw and Rendered view
     ToggleViewMode,
     /// Toggle line numbers visibility
@@ -119,6 +130,8 @@ pub enum RibbonAction {
     // Productivity
     /// Toggle productivity hub visibility
     ToggleProductivity,
+    /// Toggle Markdown quick reference panel.
+    ToggleMarkdownCheatsheet,
 
     // Frontmatter
     /// Toggle frontmatter editing panel
@@ -303,6 +316,14 @@ impl Ribbon {
                     }
                 });
 
+            ui.add_space(4.0);
+            vertical_separator(ui, separator_color, self.height() - 8.0);
+            ui.add_space(4.0);
+
+            if icon_button(ui, ARROW_LEFT, "Back to previous tab", has_editor, is_dark).clicked() {
+                action = Some(RibbonAction::PreviousTab);
+            }
+
             // Format Group (Structured data only)
             if file_type.is_structured() {
                 ui.add_space(4.0);
@@ -363,6 +384,20 @@ impl Ribbon {
             .clicked()
             {
                 action = Some(RibbonAction::FindReplace);
+            }
+
+            if file_type.is_markdown() {
+                let markdown_cheatsheet =
+                    text_button(ui, "MD", "Markdown quick reference", has_editor, is_dark);
+                ui.ctx().data_mut(|d| {
+                    d.insert_temp(
+                        markdown_cheatsheet_trigger_rect_id(),
+                        markdown_cheatsheet.rect,
+                    );
+                });
+                if markdown_cheatsheet.clicked() {
+                    action = Some(RibbonAction::ToggleMarkdownCheatsheet);
+                }
             }
 
             // ═══════════════════════════════════════════════════════════════════
@@ -517,6 +552,40 @@ fn icon_button(ui: &mut Ui, icon: &str, tooltip: &str, enabled: bool, is_dark: b
         phosphor_font(RIBBON_ICON_SIZE),
         text_color,
     );
+
+    btn.on_hover_text(tooltip)
+}
+
+fn text_button(ui: &mut Ui, label: &str, tooltip: &str, enabled: bool, is_dark: bool) -> Response {
+    let text_color = if enabled {
+        if is_dark {
+            Color32::from_rgb(220, 220, 220)
+        } else {
+            Color32::from_rgb(50, 50, 50)
+        }
+    } else if is_dark {
+        Color32::from_rgb(100, 100, 100)
+    } else {
+        Color32::from_rgb(160, 160, 160)
+    };
+
+    let hover_bg = if is_dark {
+        Color32::from_rgb(60, 60, 60)
+    } else {
+        Color32::from_rgb(220, 220, 220)
+    };
+
+    let btn = ui.add_enabled(
+        enabled,
+        egui::Button::new(RichText::new(label).size(11.5).color(text_color))
+            .frame(false)
+            .min_size(Vec2::new(34.0, 24.0)),
+    );
+
+    if btn.hovered() && enabled {
+        ui.painter()
+            .rect_filled(btn.rect, egui::CornerRadius::same(5), hover_bg);
+    }
 
     btn.on_hover_text(tooltip)
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -227,6 +227,14 @@ impl SettingsPanel {
         }
     }
 
+    /// Focus the Keyboard section and prefilter to a specific command.
+    pub fn open_keyboard_section_for(&mut self, command: ShortcutCommand) {
+        self.active_section = SettingsSection::Keyboard;
+        self.keyboard_filter = shortcut_command_name(&command);
+        self.key_capture = None;
+        self.conflict_warning = None;
+    }
+
     /// Render the settings panel inline within a tab (not as a modal window).
     ///
     /// This is used when settings are displayed as a special tab in the main


### PR DESCRIPTION
## Summary\n- Add a Mermaid diagram popup overlay with zoom/pan and click-to-open entry points.\n- Render frontmatter as a read-only properties card in rendered Markdown.\n- Add a Markdown quick reference panel in the ribbon and a previous-tab toolbar button.\n- Center rendered content for configured max line width outside Zen mode.\n\n## Validation\n- cargo check --bin ferrite\n- git diff --check\n\n## Notes\n- cargo test --bin ferrite test_mermaid_block_output_fields timed out twice during the test-profile build, so it is not claimed as passed.